### PR TITLE
Refactor slice

### DIFF
--- a/scripts/generate-full.ts
+++ b/scripts/generate-full.ts
@@ -450,7 +450,6 @@ function generateNDArrayFile(
   output.push(`// AUTO-GENERATED - DO NOT EDIT
 // Run \`npm run generate\` to regenerate this file from scripts/ndarray-methods.ts
 
-import { parseSlice, normalizeSlice } from '../common/slicing';
 import {
   type DType,
   type TypedArray,

--- a/scripts/ndarray-methods.ts
+++ b/scripts/ndarray-methods.ts
@@ -198,67 +198,6 @@ override astype(dtype: DType, copy: boolean = true): NDArray {
     return new NDArray((core as unknown as { _storage: ArrayStorage })._storage);
   }`;
 
-const SLICE_METHOD = `\
-override slice(...sliceStrs: string[]): NDArray {
-    if (sliceStrs.length === 0) {
-      return this;
-    }
-
-    if (sliceStrs.length > this.ndim) {
-      throw new Error(
-        \`Too many indices for array: array is \${this.ndim}-dimensional, but \${sliceStrs.length} were indexed\`
-      );
-    }
-
-    const sliceSpecs = sliceStrs.map((str, i) => {
-      const spec = parseSlice(str);
-      const normalized = normalizeSlice(spec, this.shape[i]!);
-      return normalized;
-    });
-
-    while (sliceSpecs.length < this.ndim) {
-      sliceSpecs.push({
-        start: 0,
-        stop: this.shape[sliceSpecs.length]!,
-        step: 1,
-        isIndex: false,
-      });
-    }
-
-    const newShape: number[] = [];
-    const newStrides: number[] = [];
-    let newOffset = this._storage.offset;
-
-    for (let i = 0; i < sliceSpecs.length; i++) {
-      const spec = sliceSpecs[i]!;
-      const stride = this._storage.strides[i]!;
-
-      newOffset += spec.start * stride;
-
-      if (!spec.isIndex) {
-        let dimSize: number;
-        if (spec.step > 0) {
-          dimSize = Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
-        } else {
-          dimSize = Math.max(0, Math.ceil((spec.start - spec.stop) / Math.abs(spec.step)));
-        }
-        newShape.push(dimSize);
-        newStrides.push(stride * spec.step);
-      }
-    }
-
-    const slicedStorage = ArrayStorage.fromData(
-      this._storage.data,
-      newShape,
-      this._storage.dtype,
-      newStrides,
-      newOffset
-    );
-
-    const base = this._base ?? this;
-    return new NDArray(slicedStorage, base);
-  }`;
-
 const RESHAPE_METHOD = `\
 reshape(...shape: number[]): NDArray {
     const newShape = shape.length === 1 && Array.isArray(shape[0]) ? shape[0] : shape;
@@ -740,13 +679,6 @@ export const METHOD_DEFS: MethodDef[] = [
   // ============================================================
   // Manual methods (slicing / indexing)
   // ============================================================
-  {
-    name: 'slice',
-    pattern: 'manual',
-    doc: 'Slice the array using NumPy-style string syntax\n@param sliceStrs - Slice specifications, one per dimension\n@returns Sliced view of the array',
-    manualCode: SLICE_METHOD,
-    flags: { isOverride: true },
-  },
   {
     name: 'row',
     pattern: 'manual',

--- a/src/common/ndarray-core.ts
+++ b/src/common/ndarray-core.ts
@@ -8,7 +8,7 @@
  * For the full NDArray with all methods, use ndarray-full.ts
  */
 
-import { parseSlice, normalizeSlice } from './slicing';
+import * as shapeOps from './ops/shape';
 import {
   type DType,
   type TypedArray,
@@ -518,58 +518,11 @@ export class NDArrayCore {
   /**
    * Slice the array
    */
-  slice(...sliceStrs: string[]): NDArrayCore {
-    if (sliceStrs.length === 0) {
-      return this;
-    }
-
-    if (sliceStrs.length > this.ndim) {
-      throw new Error(
-        `Too many indices for array: array is ${this.ndim}-dimensional, but ${sliceStrs.length} were indexed`
-      );
-    }
-
-    const sliceSpecs = sliceStrs.map((str, i) => {
-      const parsed = parseSlice(str);
-      return normalizeSlice(parsed, this.shape[i]!);
-    });
-
-    while (sliceSpecs.length < this.ndim) {
-      sliceSpecs.push({
-        start: 0,
-        stop: this.shape[sliceSpecs.length]!,
-        step: 1,
-        isIndex: false,
-      });
-    }
-
-    const newShape: number[] = [];
-    const newStrides: number[] = [];
-    let newOffset = this._storage.offset;
-
-    for (let i = 0; i < sliceSpecs.length; i++) {
-      const spec = sliceSpecs[i]!;
-      newOffset += spec.start * this._storage.strides[i]!;
-
-      if (spec.step === 0) {
-        continue;
-      }
-
-      const sliceLength = Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
-      newShape.push(sliceLength);
-      newStrides.push(this._storage.strides[i]! * spec.step);
-    }
-
-    const slicedStorage = ArrayStorage.fromData(
-      this._storage.data,
-      newShape,
-      this._storage.dtype,
-      newStrides,
-      newOffset
-    );
-
+  slice(...sliceStrs: string[]): this {
+    const slicedStorage = shapeOps.slice(this._storage, ...sliceStrs);
+    if (slicedStorage === this._storage) return this;
     const base = this._base ?? this;
-    return new NDArrayCore(slicedStorage, base);
+    return new (this.constructor as typeof NDArrayCore)(slicedStorage, base) as this;
   }
 
   /**

--- a/src/common/ops/shape.ts
+++ b/src/common/ops/shape.ts
@@ -13,6 +13,99 @@ import { wasmTile2D } from '../wasm/tile';
 import { wasmRoll } from '../wasm/roll';
 import { wasmRot90 } from '../wasm/rot90';
 import { wasmRepeat } from '../wasm/repeat';
+import { parseSlice, normalizeSlice } from '../slicing';
+
+/**
+ * Slice an array along one or more dimensions
+ * Returns a view (no data copy) with adjusted shape, strides, and offset
+ */
+export function slice(storage: ArrayStorage, ...sliceStrs: string[]): ArrayStorage {
+  if (sliceStrs.length === 0) return storage;
+
+  if (sliceStrs.length > storage.ndim) {
+    throw new Error(
+      `Too many indices for array: array is ${storage.ndim}-dimensional, but ${sliceStrs.length} were indexed`
+    );
+  }
+
+  const sliceSpecs = sliceStrs.map((str, i) => {
+    const parsed = parseSlice(str);
+    return normalizeSlice(parsed, storage.shape[i]!);
+  });
+
+  while (sliceSpecs.length < storage.ndim) {
+    sliceSpecs.push({
+      start: 0,
+      stop: storage.shape[sliceSpecs.length]!,
+      step: 1,
+      isIndex: false,
+    });
+  }
+
+  const newShape: number[] = [];
+  const newStrides: number[] = [];
+  let newOffset = storage.offset;
+
+  for (let i = 0; i < sliceSpecs.length; i++) {
+    const spec = sliceSpecs[i]!;
+    newOffset += spec.start * storage.strides[i]!;
+
+    if (spec.isIndex) continue;
+
+    const sliceLength = Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
+    newShape.push(sliceLength);
+    newStrides.push(storage.strides[i]! * spec.step);
+  }
+
+  return ArrayStorage.fromData(storage.data, newShape, storage.dtype, newStrides, newOffset);
+}
+
+/**
+ * Slice an array along one or more dimensions, keeping all dimensions (rank-preserving)
+ * Like slice(), but integer-index specs produce a size-1 dimension instead of dropping it.
+ * Returns a view (no data copy) with adjusted shape, strides, and offset
+ */
+export function sliceKeepDim(storage: ArrayStorage, ...sliceStrs: string[]): ArrayStorage {
+  if (sliceStrs.length === 0) return storage;
+
+  if (sliceStrs.length > storage.ndim) {
+    throw new Error(
+      `Too many indices for array: array is ${storage.ndim}-dimensional, but ${sliceStrs.length} were indexed`
+    );
+  }
+
+  const sliceSpecs = sliceStrs.map((str, i) => {
+    const parsed = parseSlice(str);
+    return normalizeSlice(parsed, storage.shape[i]!);
+  });
+
+  while (sliceSpecs.length < storage.ndim) {
+    sliceSpecs.push({
+      start: 0,
+      stop: storage.shape[sliceSpecs.length]!,
+      step: 1,
+      isIndex: false,
+    });
+  }
+
+  const newShape: number[] = [];
+  const newStrides: number[] = [];
+  let newOffset = storage.offset;
+
+  for (let i = 0; i < sliceSpecs.length; i++) {
+    const spec = sliceSpecs[i]!;
+    newOffset += spec.start * storage.strides[i]!;
+
+    // Unlike slice(), isIndex dimensions are kept as size-1 (rank is preserved)
+    const sliceLength = spec.isIndex
+      ? 1
+      : Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
+    newShape.push(sliceLength);
+    newStrides.push(storage.strides[i]! * spec.step);
+  }
+
+  return ArrayStorage.fromData(storage.data, newShape, storage.dtype, newStrides, newOffset);
+}
 
 /**
  * Reshape array to a new shape

--- a/src/full/ndarray.ts
+++ b/src/full/ndarray.ts
@@ -1,7 +1,6 @@
 // AUTO-GENERATED - DO NOT EDIT
 // Run `npm run generate` to regenerate this file from scripts/ndarray-methods.ts
 
-import { parseSlice, normalizeSlice } from '../common/slicing';
 import {
   type DType,
   type TypedArray,
@@ -211,71 +210,6 @@ export class NDArray extends NDArrayCore {
     const core = super.astype(dtype, copy);
     if (core instanceof NDArray) return core;
     return new NDArray((core as unknown as { _storage: ArrayStorage })._storage);
-  }
-
-  /**
-   * Slice the array using NumPy-style string syntax
-   * @param sliceStrs - Slice specifications, one per dimension
-   * @returns Sliced view of the array
-   */
-  override slice(...sliceStrs: string[]): NDArray {
-    if (sliceStrs.length === 0) {
-      return this;
-    }
-
-    if (sliceStrs.length > this.ndim) {
-      throw new Error(
-        `Too many indices for array: array is ${this.ndim}-dimensional, but ${sliceStrs.length} were indexed`
-      );
-    }
-
-    const sliceSpecs = sliceStrs.map((str, i) => {
-      const spec = parseSlice(str);
-      const normalized = normalizeSlice(spec, this.shape[i]!);
-      return normalized;
-    });
-
-    while (sliceSpecs.length < this.ndim) {
-      sliceSpecs.push({
-        start: 0,
-        stop: this.shape[sliceSpecs.length]!,
-        step: 1,
-        isIndex: false,
-      });
-    }
-
-    const newShape: number[] = [];
-    const newStrides: number[] = [];
-    let newOffset = this._storage.offset;
-
-    for (let i = 0; i < sliceSpecs.length; i++) {
-      const spec = sliceSpecs[i]!;
-      const stride = this._storage.strides[i]!;
-
-      newOffset += spec.start * stride;
-
-      if (!spec.isIndex) {
-        let dimSize: number;
-        if (spec.step > 0) {
-          dimSize = Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
-        } else {
-          dimSize = Math.max(0, Math.ceil((spec.start - spec.stop) / Math.abs(spec.step)));
-        }
-        newShape.push(dimSize);
-        newStrides.push(stride * spec.step);
-      }
-    }
-
-    const slicedStorage = ArrayStorage.fromData(
-      this._storage.data,
-      newShape,
-      this._storage.dtype,
-      newStrides,
-      newOffset
-    );
-
-    const base = this._base ?? this;
-    return new NDArray(slicedStorage, base);
   }
 
   /**

--- a/tests/unit/ndarray-core-coverage.test.ts
+++ b/tests/unit/ndarray-core-coverage.test.ts
@@ -3,6 +3,7 @@ import { NDArrayCore } from '../../src/common/ndarray-core';
 import { Complex } from '../../src/common/complex';
 import { ArrayStorage } from '../../src/common/storage';
 import type { DType } from '../../src/common/dtype';
+import { sliceKeepDim } from '../../src/common/ops/shape';
 
 /**
  * Tests for src/common/ndarray-core.ts
@@ -205,9 +206,9 @@ describe('NDArrayCore Coverage', () => {
       const a = core([1, 2, 3, 4], [2, 2]);
       const rows = [...a];
       expect(rows).toHaveLength(2);
-      // NDArrayCore.slice('0') keeps dim as size-1, so each "row" is shape [1, 2]
-      expect((rows[0] as NDArrayCore).toArray()).toEqual([[1, 2]]);
-      expect((rows[1] as NDArrayCore).toArray()).toEqual([[3, 4]]);
+      // slice('0') removes the indexed dimension, so each row is shape [2]
+      expect((rows[0] as NDArrayCore).toArray()).toEqual([1, 2]);
+      expect((rows[1] as NDArrayCore).toArray()).toEqual([3, 4]);
     });
   });
 
@@ -484,13 +485,11 @@ describe('NDArrayCore Coverage', () => {
       expect(() => a.slice('0', '1')).toThrow('Too many indices');
     });
 
-    it('scalar indexing produces size-1 dimension (NDArrayCore does not check isIndex)', () => {
+    it('scalar indexing removes dimension', () => {
       const a = core([1, 2, 3, 4, 5, 6], [2, 3]);
       const row = a.slice('0');
-      // NDArrayCore.slice uses step===0 check, but normalizeSlice returns step=1 for isIndex
-      // So scalar indexing gives size-1 dim, not dimension removal (NDArray override handles that)
-      expect(row.shape).toEqual([1, 3]);
-      expect(row.toArray()).toEqual([[1, 2, 3]]);
+      expect(row.shape).toEqual([3]);
+      expect(row.toArray()).toEqual([1, 2, 3]);
     });
 
     it('range slicing preserves dimension', () => {
@@ -521,13 +520,11 @@ describe('NDArrayCore Coverage', () => {
     it('3D array with only first dim sliced (scalar index)', () => {
       const a = core([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
       const s = a.slice('1');
-      // NDArrayCore keeps the dimension as size-1 (NDArray override removes it)
-      expect(s.shape).toEqual([1, 2, 2]);
+      // scalar index removes the dimension
+      expect(s.shape).toEqual([2, 2]);
       expect(s.toArray()).toEqual([
-        [
-          [5, 6],
-          [7, 8],
-        ],
+        [5, 6],
+        [7, 8],
       ]);
     });
 
@@ -537,6 +534,54 @@ describe('NDArrayCore Coverage', () => {
       const v2 = v1.slice('0:2');
       expect(v2.base).toBe(a);
       expect(v2.toArray()).toEqual([2, 3]);
+    });
+  });
+
+  // ========================================
+  // sliceKeepDim()
+  // ========================================
+  describe('sliceKeepDim()', () => {
+    it('scalar index keeps dimension as size-1 (unlike slice which drops it)', () => {
+      const a = core([1, 2, 3, 4, 5, 6], [2, 3]);
+      const result = sliceKeepDim(a.storage, '0');
+      expect(result.shape).toEqual([1, 3]);
+    });
+
+    it('range slice behaves identically to slice()', () => {
+      const a = core([1, 2, 3, 4, 5, 6], [2, 3]);
+      const result = sliceKeepDim(a.storage, '0:1', '1:3');
+      expect(result.shape).toEqual([1, 2]);
+    });
+
+    it('scalar index on 2D keeps both dims', () => {
+      const a = core([1, 2, 3, 4, 5, 6, 7, 8, 9], [3, 3]);
+      const result = sliceKeepDim(a.storage, '1', '1');
+      expect(result.shape).toEqual([1, 1]);
+    });
+
+    it('returns view with correct data', () => {
+      const a = core([10, 20, 30, 40, 50], [5]);
+      const result = sliceKeepDim(a.storage, '2');
+      expect(result.shape).toEqual([1]);
+      const arr = NDArrayCore.fromStorage(result);
+      expect(arr.toArray()).toEqual([30]);
+    });
+
+    it('throws for too many indices', () => {
+      const a = core([1, 2, 3], [3]);
+      expect(() => sliceKeepDim(a.storage, '0', '1')).toThrow('Too many indices');
+    });
+
+    it('pads missing dimensions with full slices', () => {
+      const a = core([1, 2, 3, 4, 5, 6], [2, 3]);
+      const result = sliceKeepDim(a.storage, '0:1');
+      expect(result.shape).toEqual([1, 3]);
+    });
+
+    it('empty call returns same storage', () => {
+      const a = core([1, 2, 3], [3]);
+      const result = sliceKeepDim(a.storage);
+      expect(result).toBe(a.storage);
     });
   });
 


### PR DESCRIPTION
- Moved logic to ops/shape.ts
- Changed ndarraycore to share same logic as ndarray, i.e. that a.slice('5') drops a dimension
- Added sliceKeepDim for legacy behavour


I cannot see why ndarraycore and ndarray diverged in behaviour. Slice is used in a few places, but this doesn't appear to have broken any tests.

There shoud be no user facing impact to this refactor.