### PR TITLE
Vindex

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -4,6 +4,15 @@ sidebarTitle: Changelog
 
 ---
 
+<Update label="v1.1.0" description="Unreleased">
+
+## numpy-ts v1.1.0
+
+* Added `vindex` — vectorized multi-dimensional indexing
+* Added slicing support for '...' and 'newaxis'
+
+</Update>
+
 <Update label="v1.0.0" description="2026-02-20">
 
 ## numpy-ts v1.0.0

--- a/docs/v1.0.x/api/indexing/advanced-indexing.mdx
+++ b/docs/v1.0.x/api/indexing/advanced-indexing.mdx
@@ -3,6 +3,60 @@ title: "Advanced Indexing"
 description: "Take, put, compress, select, broadcast, and other advanced array indexing operations."
 ---
 
+## `vindex`
+
+```typescript
+function vindex(
+  a: NDArray,
+  ...indices: (string | number[] | NDArray)[]
+): NDArray
+```
+
+`vindex` closely corresponds to [numpy's integer array indexing](https://numpy.org/doc/stable/user/basics.indexing.html#integer-array-indexing). 
+It allows selection of arbitrary items in the array based on their N-dimensional index. Each integer array represents a number of indices into that dimension.
+
+Advanced indices always are broadcast and iterated as one:
+
+```typescript
+x.vindex(ind_1, ..., ind_m)
+// Equivalent to
+// result[i_1, ..., i_M] == x[ind_1[i_1, ..., i_M], ind_2[i_1, ..., i_M],
+//                           ..., ind_N[i_1, ..., i_M]]
+
+// Example
+const m = np.array([
+  [1, 2, 3],
+  [4, 5, 6],
+  [7, 8, 9],
+]);
+m.vindex([0, 1, 2, 2], [0, 0, 1, 2])
+// [1,4,8,9]
+
+const ind = np.array([[0, 1], [1, 2]]);
+m.vindex(ind)
+// Equivalent to m.vindex(ind, ':')
+// [[[1,2,3], 
+//   [4,5,6]],
+//  [[4,5,6],
+//   [7,8,9]]]
+
+m.vindex(ind, ind)
+// [[1, 5]
+//  [5, 9]]
+
+m.vindex('1:2', ind)
+// [[[4], [5]], [[5, 6]]]
+// shape (2, 2, 1)
+// note the first dimension is now the last, numpy would give shape (1, 2, 2)
+
+```
+
+Normally vindex is called with `NDArray` or ``number[]`` objects, but you can also freely mix in any of the arguments `slice` accepts.
+The order of dimensions in the result always has the integer array index dimensions first, and any sliced dimensions following.
+This convention matches [dask's vindex](https://docs.dask.org/en/latest/generated/dask.array.Array.vindex.html), but is a departure from numpy's behaviour.
+
+---
+
 ### take
 
 Take elements from an array along an axis.

--- a/docs/v1.0.x/guides/slicing-indexing.mdx
+++ b/docs/v1.0.x/guides/slicing-indexing.mdx
@@ -102,6 +102,47 @@ m.slice('0:2', '2:4').toArray();
 When you pass an integer as a string (e.g. `'1'`), that dimension is removed from the result, just like NumPy's integer indexing. A range like `'1:2'` keeps the dimension.
 </Note>
 
+## Ellipses
+
+The string ``'...'`` expands to the number of ``':'`` slices needed to index all dimensions. In most cases, this means that the length of the expanded selection tuple is ndim. There may only be a single ellipsis present.
+
+```typescript
+const m = np.array([[
+  [0, 1, 2, 3],
+  [4, 5, 6, 7],
+  [8, 9, 10, 11],
+]]);
+// shape [1, 3, 4]
+
+// Slice just the last dimension
+m.slice('...', '1:3').toArray();
+// shape [1, 3, 2]
+// [[[1, 2],
+//   [5, 6],
+//   [9, 10]]]
+```
+
+## newaxis
+
+The string ``'newaxis'`` serves to expand the dimensions of the result by one unit-length dimension. The added dimension is the position of the newaxis object in the indices.
+
+```typescript
+const m = np.array([
+  [0, 1, 2, 3],
+  [4, 5, 6, 7],
+  [8, 9, 10, 11],
+]);
+// shape [3, 4]
+
+// Insert an axis
+m.slice(':', 'newaxis', ':').toArray();
+// shape [3, 1, 4]
+// [[[1, 2]],
+//  [[5, 6]],
+//  [[9, 10]]]
+```
+
+
 ## Negative indices
 
 Negative indices count from the end, just like Python:
@@ -282,7 +323,7 @@ Understanding when an operation returns a view (shared data) versus a copy (new 
 
 **Copies (new data):**
 - `flatten()` / `copy()`
-- `take()` / `iindex()` / `bindex()`
+- `take()` / `iindex()` / `bindex()` / `vindex()`
 - Arithmetic operations (`add`, `multiply`, etc.)
 - `sort()`, `argsort()`
 
@@ -314,6 +355,7 @@ Check `arr.base` to determine if an array is a view. If `base` is not `null`, th
 | Single row/column | `.row(i)`, `.col(j)` | View |
 | Row/column range | `.rows(a, b)`, `.cols(a, b)` | View |
 | Arbitrary integer positions | `.take(indices)` or `.iindex(indices)` | Copy |
+| Multi-axis vectorized indexing | `np.vindex(a, idx0, idx1, ...)` | Copy |
 | In-place by flat index | `.put(indices, values)` | Void (in-place) |
 | Boolean mask selection | `.bindex(mask)` | Copy |
 | Conditional pick from two arrays | `np.where(cond, x, y)` | Copy |

--- a/scripts/generate-full.ts
+++ b/scripts/generate-full.ts
@@ -141,14 +141,17 @@ function extractFunctionInfo(func: FunctionDeclaration): FunctionInfo | null {
 
   const params = func.getParameters().map(p => {
     const pName = p.getName();
-    paramNames.push(pName);  // Store the parameter name
+    const isRest = p.isRestParameter();
+    paramNames.push(isRest ? `...${pName}` : pName);  // Store the parameter name
 
     const typeNode = p.getTypeNode();
     const type = typeNode ? typeNode.getText() : 'any';
     const isOptional = p.isOptional() || p.hasInitializer();
     const initializer = p.getInitializer()?.getText();
 
-    if (initializer) {
+    if (isRest) {
+      return `...${pName}: ${type}`;
+    } else if (initializer) {
       return `${pName}: ${type} = ${initializer}`;
     } else if (isOptional) {
       return `${pName}?: ${type}`;
@@ -316,6 +319,7 @@ const up = (x: NDArrayCore): NDArray => {
 
 // Re-export types
 export type { DType, TypedArray } from '../core/types';
+export type { NDIndex } from '../core/advanced';
 export { NDArray, meshgrid } from './ndarray';
 export { NDArrayCore } from '../common/ndarray-core';
 export { Complex } from '../common/complex';

--- a/scripts/generate-full.ts
+++ b/scripts/generate-full.ts
@@ -450,7 +450,6 @@ function generateNDArrayFile(
   output.push(`// AUTO-GENERATED - DO NOT EDIT
 // Run \`npm run generate\` to regenerate this file from scripts/ndarray-methods.ts
 
-import { parseSlice, normalizeSlice } from '../common/slicing';
 import {
   type DType,
   type TypedArray,

--- a/scripts/ndarray-methods.ts
+++ b/scripts/ndarray-methods.ts
@@ -198,67 +198,6 @@ override astype(dtype: DType, copy: boolean = true): NDArray {
     return new NDArray((core as unknown as { _storage: ArrayStorage })._storage);
   }`;
 
-const SLICE_METHOD = `\
-override slice(...sliceStrs: string[]): NDArray {
-    if (sliceStrs.length === 0) {
-      return this;
-    }
-
-    if (sliceStrs.length > this.ndim) {
-      throw new Error(
-        \`Too many indices for array: array is \${this.ndim}-dimensional, but \${sliceStrs.length} were indexed\`
-      );
-    }
-
-    const sliceSpecs = sliceStrs.map((str, i) => {
-      const spec = parseSlice(str);
-      const normalized = normalizeSlice(spec, this.shape[i]!);
-      return normalized;
-    });
-
-    while (sliceSpecs.length < this.ndim) {
-      sliceSpecs.push({
-        start: 0,
-        stop: this.shape[sliceSpecs.length]!,
-        step: 1,
-        isIndex: false,
-      });
-    }
-
-    const newShape: number[] = [];
-    const newStrides: number[] = [];
-    let newOffset = this._storage.offset;
-
-    for (let i = 0; i < sliceSpecs.length; i++) {
-      const spec = sliceSpecs[i]!;
-      const stride = this._storage.strides[i]!;
-
-      newOffset += spec.start * stride;
-
-      if (!spec.isIndex) {
-        let dimSize: number;
-        if (spec.step > 0) {
-          dimSize = Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
-        } else {
-          dimSize = Math.max(0, Math.ceil((spec.start - spec.stop) / Math.abs(spec.step)));
-        }
-        newShape.push(dimSize);
-        newStrides.push(stride * spec.step);
-      }
-    }
-
-    const slicedStorage = ArrayStorage.fromData(
-      this._storage.data,
-      newShape,
-      this._storage.dtype,
-      newStrides,
-      newOffset
-    );
-
-    const base = this._base ?? this;
-    return new NDArray(slicedStorage, base);
-  }`;
-
 const RESHAPE_METHOD = `\
 reshape(...shape: number[]): NDArray {
     const newShape = shape.length === 1 && Array.isArray(shape[0]) ? shape[0] : shape;
@@ -740,13 +679,6 @@ export const METHOD_DEFS: MethodDef[] = [
   // ============================================================
   // Manual methods (slicing / indexing)
   // ============================================================
-  {
-    name: 'slice',
-    pattern: 'manual',
-    doc: 'Slice the array using NumPy-style string syntax\n@param sliceStrs - Slice specifications, one per dimension\n@returns Sliced view of the array',
-    manualCode: SLICE_METHOD,
-    flags: { isOverride: true },
-  },
   {
     name: 'row',
     pattern: 'manual',

--- a/src/common/internal/indexing.ts
+++ b/src/common/internal/indexing.ts
@@ -147,3 +147,29 @@ export function precomputeAxisOffsets(
 
   return { baseOffsets, axisStride };
 }
+/**
+ * Replaces '...' with an appropriate number of ':'.
+ * If there's not '...', it's implicit at the end.
+ *
+ *
+ * So the result of this function will have length ndim + newaxisCount
+ * where newaxisCount is the number of 'newaxis' in the input.
+ */
+export function expandEllipsis<T>(indices: (T | string)[], ndim: number): (T | string)[] {
+  const ellipsisCount = indices.filter((x) => x === '...').length;
+  const newAxisCount = indices.filter((x) => x === 'newaxis').length;
+  if (ellipsisCount > 1) throw new Error('an index can only have a single ellipsis (...)');
+  const otherCount = indices.length - ellipsisCount - newAxisCount;
+  const replacements = ndim - otherCount;
+  if (replacements < 0)
+    throw new Error(
+      `Too many indices for array: array is ${ndim}-dimensional, but ${otherCount} were indexed`
+    );
+  if (replacements === 0 && ellipsisCount === 0) return indices;
+
+  const ellipsisIndex = ellipsisCount === 0 ? indices.length : indices.indexOf('...');
+  const result = indices.slice();
+  result.splice(ellipsisIndex, ellipsisCount, ...Array(replacements).fill(':'));
+
+  return result;
+}

--- a/src/common/ndarray-core.ts
+++ b/src/common/ndarray-core.ts
@@ -8,7 +8,7 @@
  * For the full NDArray with all methods, use ndarray-full.ts
  */
 
-import { parseSlice, normalizeSlice } from './slicing';
+import * as shapeOps from './ops/shape';
 import {
   type DType,
   type TypedArray,
@@ -518,58 +518,11 @@ export class NDArrayCore {
   /**
    * Slice the array
    */
-  slice(...sliceStrs: string[]): NDArrayCore {
-    if (sliceStrs.length === 0) {
-      return this;
-    }
-
-    if (sliceStrs.length > this.ndim) {
-      throw new Error(
-        `Too many indices for array: array is ${this.ndim}-dimensional, but ${sliceStrs.length} were indexed`
-      );
-    }
-
-    const sliceSpecs = sliceStrs.map((str, i) => {
-      const parsed = parseSlice(str);
-      return normalizeSlice(parsed, this.shape[i]!);
-    });
-
-    while (sliceSpecs.length < this.ndim) {
-      sliceSpecs.push({
-        start: 0,
-        stop: this.shape[sliceSpecs.length]!,
-        step: 1,
-        isIndex: false,
-      });
-    }
-
-    const newShape: number[] = [];
-    const newStrides: number[] = [];
-    let newOffset = this._storage.offset;
-
-    for (let i = 0; i < sliceSpecs.length; i++) {
-      const spec = sliceSpecs[i]!;
-      newOffset += spec.start * this._storage.strides[i]!;
-
-      if (spec.step === 0) {
-        continue;
-      }
-
-      const sliceLength = Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
-      newShape.push(sliceLength);
-      newStrides.push(this._storage.strides[i]! * spec.step);
-    }
-
-    const slicedStorage = ArrayStorage.fromData(
-      this._storage.data,
-      newShape,
-      this._storage.dtype,
-      newStrides,
-      newOffset
-    );
-
+  slice(...sliceStrs: string[]): this {
+    const slicedStorage = shapeOps.slice(this._storage, ...sliceStrs);
+    if (slicedStorage === this._storage) return this;
     const base = this._base ?? this;
-    return new NDArrayCore(slicedStorage, base);
+    return new (this.constructor as typeof NDArrayCore)(slicedStorage, base) as this;
   }
 
   /**

--- a/src/common/ops/advanced.ts
+++ b/src/common/ops/advanced.ts
@@ -10,7 +10,7 @@ import { getTypedArrayConstructor, isBigIntDType, isComplexDType, type TypedArra
 import { computeBroadcastShape, broadcastTo, broadcastShapes } from '../broadcasting';
 import { Complex } from '../complex';
 import { parseSlice } from '../slicing';
-import { multiIndexToLinear } from '../internal/indexing';
+import { expandEllipsis, multiIndexToLinear } from '../internal/indexing';
 import { slice as storageSlice, transpose as storageTranspose } from './shape';
 
 /**
@@ -1650,29 +1650,6 @@ export function seterr(
 
 type StorageIndex = number | string | number[] | ArrayStorage;
 
-function expandEllipsis(indices: unknown[], ndim: number): unknown[] {
-  const ellipsisCount = indices.filter((x) => x === '...').length;
-  if (ellipsisCount > 1) throw new Error('an index can only have a single ellipsis (...)');
-
-  // Pad missing trailing indices with ':' (numpy semantics)
-  const withoutEllipsis = ellipsisCount === 0 ? indices : indices.filter((x) => x !== '...');
-  const nonTrailingCount = withoutEllipsis.length;
-  const padding = Array(ndim - nonTrailingCount).fill(':');
-
-  if (ellipsisCount === 0) return [...indices, ...padding];
-
-  // Replace '...' with the appropriate number of ':' entries
-  const result: unknown[] = [];
-  for (const idx of indices) {
-    if (idx === '...') {
-      result.push(...padding);
-    } else {
-      result.push(idx);
-    }
-  }
-  return result;
-}
-
 function numberArrayToStorage(values: number[]): ArrayStorage {
   return ArrayStorage.fromData(new Int32Array(values), [values.length], 'int32');
 }
@@ -1692,7 +1669,7 @@ function numberArrayToStorage(values: number[]): ArrayStorage {
  */
 export function vindex(a: ArrayStorage, ...indices: StorageIndex[]): ArrayStorage {
   // expand ellipsis and auto-pad missing trailing dims with ':'
-  const expanded = expandEllipsis(indices, a.ndim) as StorageIndex[];
+  const expanded = expandEllipsis(indices, a.ndim);
 
   // Split indices into simple slicing operations, and integer array indexing
   let sliceIndices: string[] = [];
@@ -1700,6 +1677,9 @@ export function vindex(a: ArrayStorage, ...indices: StorageIndex[]): ArrayStorag
   for (const ind of expanded) {
     if (typeof ind === 'number') {
       sliceIndices.push(ind.toString());
+    } else if (ind === 'newaxis') {
+      sliceIndices.push(ind);
+      arrayIndices.push(':');
     } else if (typeof ind === 'string') {
       const slice = parseSlice(ind);
       if (slice.isIndex) {

--- a/src/common/ops/advanced.ts
+++ b/src/common/ops/advanced.ts
@@ -6,9 +6,12 @@
  */
 
 import { ArrayStorage, computeStrides } from '../storage';
-import { getTypedArrayConstructor, isBigIntDType, type TypedArray } from '../dtype';
+import { getTypedArrayConstructor, isBigIntDType, isComplexDType, type TypedArray } from '../dtype';
 import { computeBroadcastShape, broadcastTo, broadcastShapes } from '../broadcasting';
 import { Complex } from '../complex';
+import { parseSlice } from '../slicing';
+import { multiIndexToLinear } from '../internal/indexing';
+import { slice as storageSlice, transpose as storageTranspose } from './shape';
 
 /**
  * Broadcast an array to a given shape
@@ -1639,4 +1642,151 @@ export function seterr(
   if (invalid !== undefined) _floatErrorState.invalid = invalid;
 
   return old;
+}
+
+// ============================================================
+// Vectorized Multi-dimensional Indexing (vindex)
+// ============================================================
+
+type StorageIndex = number | string | number[] | ArrayStorage;
+
+function expandEllipsis(indices: unknown[], ndim: number): unknown[] {
+  const ellipsisCount = indices.filter((x) => x === '...').length;
+  if (ellipsisCount > 1) throw new Error('an index can only have a single ellipsis (...)');
+
+  // Pad missing trailing indices with ':' (numpy semantics)
+  const withoutEllipsis = ellipsisCount === 0 ? indices : indices.filter((x) => x !== '...');
+  const nonTrailingCount = withoutEllipsis.length;
+  const padding = Array(ndim - nonTrailingCount).fill(':');
+
+  if (ellipsisCount === 0) return [...indices, ...padding];
+
+  // Replace '...' with the appropriate number of ':' entries
+  const result: unknown[] = [];
+  for (const idx of indices) {
+    if (idx === '...') {
+      result.push(...padding);
+    } else {
+      result.push(idx);
+    }
+  }
+  return result;
+}
+
+function numberArrayToStorage(values: number[]): ArrayStorage {
+  return ArrayStorage.fromData(new Int32Array(values), [values.length], 'int32');
+}
+
+/**
+ * Vectorized multi-dimensional indexing.
+ *
+ * Integer-array subspace dimensions come first in the output, followed by
+ * slice dimensions in their original order.
+ *
+ * Supported index types:
+ *   number        — scalar, removes the dimension
+ *   string '1:4'  — range slice
+ *   string '...'  — ellipsis, expands to fill remaining dimensions
+ *   number[]      — cast to 1-d integer index array
+ *   ArrayStorage  — integer array indexing
+ */
+export function vindex(a: ArrayStorage, ...indices: StorageIndex[]): ArrayStorage {
+  // expand ellipsis and auto-pad missing trailing dims with ':'
+  const expanded = expandEllipsis(indices, a.ndim) as StorageIndex[];
+
+  // Split indices into simple slicing operations, and integer array indexing
+  let sliceIndices: string[] = [];
+  let arrayIndices: (ArrayStorage | ':')[] = [];
+  for (const ind of expanded) {
+    if (typeof ind === 'number') {
+      sliceIndices.push(ind.toString());
+    } else if (typeof ind === 'string') {
+      const slice = parseSlice(ind);
+      if (slice.isIndex) {
+        sliceIndices.push(ind);
+      } else {
+        sliceIndices.push(ind);
+        arrayIndices.push(':');
+      }
+    } else if (Array.isArray(ind)) {
+      sliceIndices.push(':');
+      arrayIndices.push(numberArrayToStorage(ind));
+    } else {
+      sliceIndices.push(':');
+      arrayIndices.push(ind);
+    }
+  }
+
+  // Do the simple slicing first
+  a = storageSlice(a, ...sliceIndices);
+
+  // Now go on to do integer array indexing
+
+  // Transpose a so dimensions covered by indexing operations (I) are first and then the rest (R)
+  let arrayIndexesFiltered: ArrayStorage[] = [];
+  let transposeI: number[] = [];
+  let transposeR: number[] = [];
+  let shapeR: number[] = [];
+  for (let i = 0; i < a.ndim; i++) {
+    let ind = arrayIndices[i];
+    if (ind instanceof ArrayStorage) {
+      arrayIndexesFiltered.push(ind);
+      transposeI.push(i);
+    } else {
+      transposeR.push(i);
+      shapeR.push(a.shape[i]!);
+    }
+  }
+  a = storageTranspose(a, [...transposeI, ...transposeR]);
+
+  // Broadcast the array indices
+  arrayIndexesFiltered = broadcast_arrays(arrayIndexesFiltered);
+  const shapeI: number[] =
+    arrayIndexesFiltered.length > 0 ? Array.from(arrayIndexesFiltered[0]!.shape) : [];
+  const sizeI: number = shapeI.reduce((p, d) => p * d, 1);
+  const sizeR: number = shapeR.reduce((p, d) => p * d, 1);
+
+  // Allocate output
+  const outputShape = [...shapeI, ...shapeR];
+  const Constructor = getTypedArrayConstructor(a.dtype)!;
+  const outputSize = sizeI * sizeR;
+  const physicalSize = isComplexDType(a.dtype) ? outputSize * 2 : outputSize;
+  const outputData = new Constructor(physicalSize);
+  const outputStorage = ArrayStorage.fromData(outputData, outputShape, a.dtype);
+
+  if (outputSize === 0) return outputStorage;
+
+  const baseIndexR = shapeR.map((_) => 0);
+  for (let i = 0; i < sizeI; i++) {
+    const indexI = arrayIndexesFiltered.map((ind) => ind.iget(i) as number);
+
+    // Validate and handle negative integers
+    for (let j = 0; j < indexI.length; j++) {
+      let index = indexI[j]!;
+      if (index < 0) index = indexI[j] = a.shape[j]! + index;
+      if (index < 0 || index >= a.shape[j]!) {
+        throw new Error(`index ${index} is out of bounds for axis with size ${a.shape[j]!}`);
+      }
+    }
+
+    // Convert to linear index
+    const index = [...indexI, ...baseIndexR];
+    const linear = multiIndexToLinear(index, a.shape);
+
+    // Copy slice(a, ...indexI) to outputStorage[i]
+    if (isComplexDType(a.dtype)) {
+      for (let j = 0; j < sizeR; j++) {
+        const value = a.iget(linear + j) as Complex;
+        const physicalIndex = (i * sizeR + j) * 2;
+        outputStorage.data[physicalIndex] = value.re;
+        outputStorage.data[physicalIndex + 1] = value.im;
+      }
+    } else {
+      for (let j = 0; j < sizeR; j++) {
+        outputStorage.data[i * sizeR + j] = a.iget(linear + j) as number | bigint;
+      }
+    }
+  }
+
+  return outputStorage;
 }

--- a/src/common/ops/shape.ts
+++ b/src/common/ops/shape.ts
@@ -13,6 +13,99 @@ import { wasmTile2D } from '../wasm/tile';
 import { wasmRoll } from '../wasm/roll';
 import { wasmRot90 } from '../wasm/rot90';
 import { wasmRepeat } from '../wasm/repeat';
+import { parseSlice, normalizeSlice } from '../slicing';
+
+/**
+ * Slice an array along one or more dimensions
+ * Returns a view (no data copy) with adjusted shape, strides, and offset
+ */
+export function slice(storage: ArrayStorage, ...sliceStrs: string[]): ArrayStorage {
+  if (sliceStrs.length === 0) return storage;
+
+  if (sliceStrs.length > storage.ndim) {
+    throw new Error(
+      `Too many indices for array: array is ${storage.ndim}-dimensional, but ${sliceStrs.length} were indexed`
+    );
+  }
+
+  const sliceSpecs = sliceStrs.map((str, i) => {
+    const parsed = parseSlice(str);
+    return normalizeSlice(parsed, storage.shape[i]!);
+  });
+
+  while (sliceSpecs.length < storage.ndim) {
+    sliceSpecs.push({
+      start: 0,
+      stop: storage.shape[sliceSpecs.length]!,
+      step: 1,
+      isIndex: false,
+    });
+  }
+
+  const newShape: number[] = [];
+  const newStrides: number[] = [];
+  let newOffset = storage.offset;
+
+  for (let i = 0; i < sliceSpecs.length; i++) {
+    const spec = sliceSpecs[i]!;
+    newOffset += spec.start * storage.strides[i]!;
+
+    if (spec.isIndex) continue;
+
+    const sliceLength = Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
+    newShape.push(sliceLength);
+    newStrides.push(storage.strides[i]! * spec.step);
+  }
+
+  return ArrayStorage.fromData(storage.data, newShape, storage.dtype, newStrides, newOffset);
+}
+
+/**
+ * Slice an array along one or more dimensions, keeping all dimensions (rank-preserving)
+ * Like slice(), but integer-index specs produce a size-1 dimension instead of dropping it.
+ * Returns a view (no data copy) with adjusted shape, strides, and offset
+ */
+export function sliceKeepDim(storage: ArrayStorage, ...sliceStrs: string[]): ArrayStorage {
+  if (sliceStrs.length === 0) return storage;
+
+  if (sliceStrs.length > storage.ndim) {
+    throw new Error(
+      `Too many indices for array: array is ${storage.ndim}-dimensional, but ${sliceStrs.length} were indexed`
+    );
+  }
+
+  const sliceSpecs = sliceStrs.map((str, i) => {
+    const parsed = parseSlice(str);
+    return normalizeSlice(parsed, storage.shape[i]!);
+  });
+
+  while (sliceSpecs.length < storage.ndim) {
+    sliceSpecs.push({
+      start: 0,
+      stop: storage.shape[sliceSpecs.length]!,
+      step: 1,
+      isIndex: false,
+    });
+  }
+
+  const newShape: number[] = [];
+  const newStrides: number[] = [];
+  let newOffset = storage.offset;
+
+  for (let i = 0; i < sliceSpecs.length; i++) {
+    const spec = sliceSpecs[i]!;
+    newOffset += spec.start * storage.strides[i]!;
+
+    // Unlike slice(), isIndex dimensions are kept as size-1 (rank is preserved)
+    const sliceLength = spec.isIndex
+      ? 1
+      : Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
+    newShape.push(sliceLength);
+    newStrides.push(storage.strides[i]! * spec.step);
+  }
+
+  return ArrayStorage.fromData(storage.data, newShape, storage.dtype, newStrides, newOffset);
+}
 
 /**
  * Reshape array to a new shape

--- a/src/common/ops/shape.ts
+++ b/src/common/ops/shape.ts
@@ -14,6 +14,7 @@ import { wasmRoll } from '../wasm/roll';
 import { wasmRot90 } from '../wasm/rot90';
 import { wasmRepeat } from '../wasm/repeat';
 import { parseSlice, normalizeSlice } from '../slicing';
+import { expandEllipsis } from '../internal/indexing';
 
 /**
  * Slice an array along one or more dimensions
@@ -22,39 +23,31 @@ import { parseSlice, normalizeSlice } from '../slicing';
 export function slice(storage: ArrayStorage, ...sliceStrs: string[]): ArrayStorage {
   if (sliceStrs.length === 0) return storage;
 
-  if (sliceStrs.length > storage.ndim) {
-    throw new Error(
-      `Too many indices for array: array is ${storage.ndim}-dimensional, but ${sliceStrs.length} were indexed`
-    );
-  }
-
-  const sliceSpecs = sliceStrs.map((str, i) => {
-    const parsed = parseSlice(str);
-    return normalizeSlice(parsed, storage.shape[i]!);
-  });
-
-  while (sliceSpecs.length < storage.ndim) {
-    sliceSpecs.push({
-      start: 0,
-      stop: storage.shape[sliceSpecs.length]!,
-      step: 1,
-      isIndex: false,
-    });
-  }
+  sliceStrs = expandEllipsis(sliceStrs, storage.ndim);
 
   const newShape: number[] = [];
   const newStrides: number[] = [];
   let newOffset = storage.offset;
 
-  for (let i = 0; i < sliceSpecs.length; i++) {
-    const spec = sliceSpecs[i]!;
-    newOffset += spec.start * storage.strides[i]!;
+  let axis = 0;
+  for (let i = 0; i < sliceStrs.length; i++) {
+    const str = sliceStrs[i]!;
+    if (str === 'newaxis') {
+      newShape.push(1);
+      newStrides.push(0);
+    } else {
+      const parsed = parseSlice(str);
+      const spec = normalizeSlice(parsed, storage.shape[axis]!);
+      const stride = storage.strides[axis]!;
+      axis++;
+      newOffset += spec.start * stride;
 
-    if (spec.isIndex) continue;
+      if (spec.isIndex) continue;
 
-    const sliceLength = Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
-    newShape.push(sliceLength);
-    newStrides.push(storage.strides[i]! * spec.step);
+      const sliceLength = Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
+      newShape.push(sliceLength);
+      newStrides.push(stride * spec.step);
+    }
   }
 
   return ArrayStorage.fromData(storage.data, newShape, storage.dtype, newStrides, newOffset);
@@ -68,40 +61,32 @@ export function slice(storage: ArrayStorage, ...sliceStrs: string[]): ArrayStora
 export function sliceKeepDim(storage: ArrayStorage, ...sliceStrs: string[]): ArrayStorage {
   if (sliceStrs.length === 0) return storage;
 
-  if (sliceStrs.length > storage.ndim) {
-    throw new Error(
-      `Too many indices for array: array is ${storage.ndim}-dimensional, but ${sliceStrs.length} were indexed`
-    );
-  }
-
-  const sliceSpecs = sliceStrs.map((str, i) => {
-    const parsed = parseSlice(str);
-    return normalizeSlice(parsed, storage.shape[i]!);
-  });
-
-  while (sliceSpecs.length < storage.ndim) {
-    sliceSpecs.push({
-      start: 0,
-      stop: storage.shape[sliceSpecs.length]!,
-      step: 1,
-      isIndex: false,
-    });
-  }
+  sliceStrs = expandEllipsis(sliceStrs, storage.ndim);
 
   const newShape: number[] = [];
   const newStrides: number[] = [];
   let newOffset = storage.offset;
 
-  for (let i = 0; i < sliceSpecs.length; i++) {
-    const spec = sliceSpecs[i]!;
-    newOffset += spec.start * storage.strides[i]!;
+  let axis = 0;
+  for (let i = 0; i < sliceStrs.length; i++) {
+    const str = sliceStrs[i]!;
+    if (str === 'newaxis') {
+      newShape.push(1);
+      newStrides.push(0);
+    } else {
+      const parsed = parseSlice(str);
+      const spec = normalizeSlice(parsed, storage.shape[axis]!);
+      const stride = storage.strides[axis]!;
+      axis++;
+      newOffset += spec.start * stride;
 
-    // Unlike slice(), isIndex dimensions are kept as size-1 (rank is preserved)
-    const sliceLength = spec.isIndex
-      ? 1
-      : Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
-    newShape.push(sliceLength);
-    newStrides.push(storage.strides[i]! * spec.step);
+      // Unlike slice(), isIndex dimensions are kept as size-1 (rank is preserved)
+      const sliceLength = spec.isIndex
+        ? 1
+        : Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
+      newShape.push(sliceLength);
+      newStrides.push(stride * spec.step);
+    }
   }
 
   return ArrayStorage.fromData(storage.data, newShape, storage.dtype, newStrides, newOffset);

--- a/src/core/advanced.ts
+++ b/src/core/advanced.ts
@@ -331,3 +331,25 @@ export function shares_memory(a: NDArrayCore, b: NDArrayCore): boolean {
 
 export const geterr = advancedOps.geterr;
 export const seterr = advancedOps.seterr;
+
+// ============================================================
+// Vectorized Multi-dimensional Indexing
+// ============================================================
+
+export type NDIndex = number | string | number[] | NDArrayCore;
+
+/**
+ * Vectorized multi-dimensional indexing (dask.vindex semantics).
+ *
+ * Integer-array subspace dimensions come first in the output, followed by
+ * slice dimensions in their original order.
+ */
+export function vindex(
+  a: NDArrayCore,
+  ...indices: (number | string | number[] | NDArrayCore)[]
+): NDArrayCore {
+  const storageIndices = indices.map((idx) =>
+    idx instanceof NDArrayCore ? toStorage(idx) : idx
+  ) as (number | string | number[] | ArrayStorage)[];
+  return fromStorage(advancedOps.vindex(toStorage(a), ...storageIndices));
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -382,7 +382,9 @@ export {
   seterr,
   iindex,
   bindex,
+  vindex,
 } from './advanced';
+export type { NDIndex } from './advanced';
 
 // Formatting and printing functions
 export {

--- a/src/full/index.ts
+++ b/src/full/index.ts
@@ -39,6 +39,7 @@ const up = (x: NDArrayCore): NDArray => {
 
 // Re-export types
 export type { DType, TypedArray } from '../core/types';
+export type { NDIndex } from '../core/advanced';
 export { NDArray, meshgrid } from './ndarray';
 export { NDArrayCore } from '../common/ndarray-core';
 export { Complex } from '../common/complex';
@@ -169,6 +170,19 @@ export function apply_over_axes(
     return func(up(arr), axis);
   };
   return up(core.apply_over_axes(wrappedFunc, a, axes));
+}
+
+/**
+ * Vectorized multi-dimensional indexing (dask.vindex semantics).
+ *
+ * Integer-array subspace dimensions come first in the output, followed by
+ * slice dimensions in their original order.
+ */
+export function vindex(
+  a: NDArrayCore,
+  ...indices: (number | string | number[] | NDArrayCore)[]
+): NDArray {
+  return up(core.vindex(a, ...indices));
 }
 
 /** Add arguments element-wise */

--- a/src/full/ndarray.ts
+++ b/src/full/ndarray.ts
@@ -1,7 +1,6 @@
 // AUTO-GENERATED - DO NOT EDIT
 // Run `npm run generate` to regenerate this file from scripts/ndarray-methods.ts
 
-import { parseSlice, normalizeSlice } from '../common/slicing';
 import {
   type DType,
   type TypedArray,
@@ -211,71 +210,6 @@ export class NDArray extends NDArrayCore {
     const core = super.astype(dtype, copy);
     if (core instanceof NDArray) return core;
     return new NDArray((core as unknown as { _storage: ArrayStorage })._storage);
-  }
-
-  /**
-   * Slice the array using NumPy-style string syntax
-   * @param sliceStrs - Slice specifications, one per dimension
-   * @returns Sliced view of the array
-   */
-  override slice(...sliceStrs: string[]): NDArray {
-    if (sliceStrs.length === 0) {
-      return this;
-    }
-
-    if (sliceStrs.length > this.ndim) {
-      throw new Error(
-        `Too many indices for array: array is ${this.ndim}-dimensional, but ${sliceStrs.length} were indexed`
-      );
-    }
-
-    const sliceSpecs = sliceStrs.map((str, i) => {
-      const spec = parseSlice(str);
-      const normalized = normalizeSlice(spec, this.shape[i]!);
-      return normalized;
-    });
-
-    while (sliceSpecs.length < this.ndim) {
-      sliceSpecs.push({
-        start: 0,
-        stop: this.shape[sliceSpecs.length]!,
-        step: 1,
-        isIndex: false,
-      });
-    }
-
-    const newShape: number[] = [];
-    const newStrides: number[] = [];
-    let newOffset = this._storage.offset;
-
-    for (let i = 0; i < sliceSpecs.length; i++) {
-      const spec = sliceSpecs[i]!;
-      const stride = this._storage.strides[i]!;
-
-      newOffset += spec.start * stride;
-
-      if (!spec.isIndex) {
-        let dimSize: number;
-        if (spec.step > 0) {
-          dimSize = Math.max(0, Math.ceil((spec.stop - spec.start) / spec.step));
-        } else {
-          dimSize = Math.max(0, Math.ceil((spec.start - spec.stop) / Math.abs(spec.step)));
-        }
-        newShape.push(dimSize);
-        newStrides.push(stride * spec.step);
-      }
-    }
-
-    const slicedStorage = ArrayStorage.fromData(
-      this._storage.data,
-      newShape,
-      this._storage.dtype,
-      newStrides,
-      newOffset
-    );
-
-    const base = this._base ?? this;
-    return new NDArray(slicedStorage, base);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -442,6 +442,7 @@ export {
   put,
   iindex,
   bindex,
+  vindex,
   copyto,
   choose,
   array_equal,
@@ -472,6 +473,7 @@ export {
   view,
   tofile,
 } from './full';
+export type { NDIndex } from './full';
 
 // ============================================================
 // Utility Functions

--- a/tests/unit/ndarray-core-coverage.test.ts
+++ b/tests/unit/ndarray-core-coverage.test.ts
@@ -3,6 +3,7 @@ import { NDArrayCore } from '../../src/common/ndarray-core';
 import { Complex } from '../../src/common/complex';
 import { ArrayStorage } from '../../src/common/storage';
 import type { DType } from '../../src/common/dtype';
+import { sliceKeepDim } from '../../src/common/ops/shape';
 
 /**
  * Tests for src/common/ndarray-core.ts
@@ -205,9 +206,9 @@ describe('NDArrayCore Coverage', () => {
       const a = core([1, 2, 3, 4], [2, 2]);
       const rows = [...a];
       expect(rows).toHaveLength(2);
-      // NDArrayCore.slice('0') keeps dim as size-1, so each "row" is shape [1, 2]
-      expect((rows[0] as NDArrayCore).toArray()).toEqual([[1, 2]]);
-      expect((rows[1] as NDArrayCore).toArray()).toEqual([[3, 4]]);
+      // slice('0') removes the indexed dimension, so each row is shape [2]
+      expect((rows[0] as NDArrayCore).toArray()).toEqual([1, 2]);
+      expect((rows[1] as NDArrayCore).toArray()).toEqual([3, 4]);
     });
   });
 
@@ -484,13 +485,11 @@ describe('NDArrayCore Coverage', () => {
       expect(() => a.slice('0', '1')).toThrow('Too many indices');
     });
 
-    it('scalar indexing produces size-1 dimension (NDArrayCore does not check isIndex)', () => {
+    it('scalar indexing removes dimension', () => {
       const a = core([1, 2, 3, 4, 5, 6], [2, 3]);
       const row = a.slice('0');
-      // NDArrayCore.slice uses step===0 check, but normalizeSlice returns step=1 for isIndex
-      // So scalar indexing gives size-1 dim, not dimension removal (NDArray override handles that)
-      expect(row.shape).toEqual([1, 3]);
-      expect(row.toArray()).toEqual([[1, 2, 3]]);
+      expect(row.shape).toEqual([3]);
+      expect(row.toArray()).toEqual([1, 2, 3]);
     });
 
     it('range slicing preserves dimension', () => {
@@ -521,13 +520,11 @@ describe('NDArrayCore Coverage', () => {
     it('3D array with only first dim sliced (scalar index)', () => {
       const a = core([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
       const s = a.slice('1');
-      // NDArrayCore keeps the dimension as size-1 (NDArray override removes it)
-      expect(s.shape).toEqual([1, 2, 2]);
+      // scalar index removes the dimension
+      expect(s.shape).toEqual([2, 2]);
       expect(s.toArray()).toEqual([
-        [
-          [5, 6],
-          [7, 8],
-        ],
+        [5, 6],
+        [7, 8],
       ]);
     });
 
@@ -537,6 +534,54 @@ describe('NDArrayCore Coverage', () => {
       const v2 = v1.slice('0:2');
       expect(v2.base).toBe(a);
       expect(v2.toArray()).toEqual([2, 3]);
+    });
+  });
+
+  // ========================================
+  // sliceKeepDim()
+  // ========================================
+  describe('sliceKeepDim()', () => {
+    it('scalar index keeps dimension as size-1 (unlike slice which drops it)', () => {
+      const a = core([1, 2, 3, 4, 5, 6], [2, 3]);
+      const result = sliceKeepDim(a.storage, '0');
+      expect(result.shape).toEqual([1, 3]);
+    });
+
+    it('range slice behaves identically to slice()', () => {
+      const a = core([1, 2, 3, 4, 5, 6], [2, 3]);
+      const result = sliceKeepDim(a.storage, '0:1', '1:3');
+      expect(result.shape).toEqual([1, 2]);
+    });
+
+    it('scalar index on 2D keeps both dims', () => {
+      const a = core([1, 2, 3, 4, 5, 6, 7, 8, 9], [3, 3]);
+      const result = sliceKeepDim(a.storage, '1', '1');
+      expect(result.shape).toEqual([1, 1]);
+    });
+
+    it('returns view with correct data', () => {
+      const a = core([10, 20, 30, 40, 50], [5]);
+      const result = sliceKeepDim(a.storage, '2');
+      expect(result.shape).toEqual([1]);
+      const arr = NDArrayCore.fromStorage(result);
+      expect(arr.toArray()).toEqual([30]);
+    });
+
+    it('throws for too many indices', () => {
+      const a = core([1, 2, 3], [3]);
+      expect(() => sliceKeepDim(a.storage, '0', '1')).toThrow('Too many indices');
+    });
+
+    it('pads missing dimensions with full slices', () => {
+      const a = core([1, 2, 3, 4, 5, 6], [2, 3]);
+      const result = sliceKeepDim(a.storage, '0:1');
+      expect(result.shape).toEqual([1, 3]);
+    });
+
+    it('empty call returns same storage', () => {
+      const a = core([1, 2, 3], [3]);
+      const result = sliceKeepDim(a.storage);
+      expect(result).toBe(a.storage);
     });
   });
 

--- a/tests/unit/ndarray.test.ts
+++ b/tests/unit/ndarray.test.ts
@@ -577,6 +577,101 @@ describe('NDArray Slicing', () => {
       expect(() => arr.slice('-10')).toThrow(/out of bounds/);
     });
   });
+
+  describe('slice with ellipsis (...)', () => {
+    it('"..." alone is identity on 1D', () => {
+      const arr = array([1, 2, 3, 4, 5]);
+      const result = arr.slice('...');
+      expect(result.shape).toEqual([5]);
+      expect(result.toArray()).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('"..." alone is identity on 2D', () => {
+      const arr = array([[1, 2, 3], [4, 5, 6]]);
+      const result = arr.slice('...');
+      expect(result.shape).toEqual([2, 3]);
+      expect(result.toArray()).toEqual([[1, 2, 3], [4, 5, 6]]);
+    });
+
+    it('"...", "1:3" slices last dim of 2D', () => {
+      const arr = array([[1, 2, 3], [4, 5, 6]]);
+      const result = arr.slice('...', '1:3');
+      expect(result.shape).toEqual([2, 2]);
+      expect(result.toArray()).toEqual([[2, 3], [5, 6]]);
+    });
+
+    it('"1", "..." scalar on first dim of 2D', () => {
+      const arr = array([[1, 2, 3], [4, 5, 6]]);
+      const result = arr.slice('1', '...');
+      expect(result.shape).toEqual([3]);
+      expect(result.toArray()).toEqual([4, 5, 6]);
+    });
+
+    it('"...", "0" scalar on last dim of 3D', () => {
+      const arr = array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]);
+      const result = arr.slice('...', '0');
+      expect(result.shape).toEqual([2, 2]);
+      expect(result.toArray()).toEqual([[1, 3], [5, 7]]);
+    });
+
+    it('throws on multiple ellipses', () => {
+      const arr = array([[1, 2], [3, 4]]);
+      expect(() => arr.slice('...', '...')).toThrow(/ellipsis/);
+    });
+  });
+
+  describe('slice with newaxis', () => {
+    it('"newaxis" inserts leading dim on 1D', () => {
+      const arr = array([1, 2, 3]);
+      const result = arr.slice('newaxis');
+      expect(result.shape).toEqual([1, 3]);
+      expect(result.toArray()).toEqual([[1, 2, 3]]);
+    });
+
+    it('":", "newaxis" inserts trailing dim on 1D', () => {
+      const arr = array([1, 2, 3]);
+      const result = arr.slice(':', 'newaxis');
+      expect(result.shape).toEqual([3, 1]);
+    });
+
+    it('"newaxis", ":", ":" inserts leading dim on 2D', () => {
+      const arr = array([[1, 2], [3, 4]]);
+      const result = arr.slice('newaxis', ':', ':');
+      expect(result.shape).toEqual([1, 2, 2]);
+      expect(result.toArray()).toEqual([[[1, 2], [3, 4]]]);
+    });
+
+    it('":", "newaxis", ":" inserts middle dim on 2D', () => {
+      const arr = array([[1, 2, 3], [4, 5, 6]]);
+      const result = arr.slice(':', 'newaxis', ':');
+      expect(result.shape).toEqual([2, 1, 3]);
+    });
+
+    it('":", ":", "newaxis" inserts trailing dim on 2D', () => {
+      const arr = array([[1, 2], [3, 4]]);
+      const result = arr.slice(':', ':', 'newaxis');
+      expect(result.shape).toEqual([2, 2, 1]);
+    });
+
+    it('multiple newaxis entries', () => {
+      const arr = array([1, 2, 3]);
+      const result = arr.slice('newaxis', ':', 'newaxis');
+      expect(result.shape).toEqual([1, 3, 1]);
+    });
+
+    it('newaxis after scalar index', () => {
+      const arr = array([[1, 2, 3], [4, 5, 6]]);
+      const result = arr.slice('0', 'newaxis', ':');
+      expect(result.shape).toEqual([1, 3]);
+      expect(result.toArray()).toEqual([[1, 2, 3]]);
+    });
+
+    it('"...", "newaxis" inserts trailing dim via ellipsis', () => {
+      const arr = array([[1, 2], [3, 4]]);
+      const result = arr.slice('...', 'newaxis');
+      expect(result.shape).toEqual([2, 2, 1]);
+    });
+  });
 });
 
 describe('NDArrayCore specific', () => {

--- a/tests/unit/vindex.test.ts
+++ b/tests/unit/vindex.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for vindex — vectorized multi-dimensional indexing
+ */
+
+import { describe, it, expect } from 'vitest';
+import { array, arange, vindex, Complex } from '../../src';
+
+describe('vindex', () => {
+  // ========================================
+  // Scalar indexing
+  // ========================================
+  describe('scalar indices', () => {
+    it('removes a dimension on 2D array', () => {
+      const a = arange(15).reshape([5, 3]);
+      const result = vindex(a, 1);
+      expect(result.shape).toEqual([3]);
+      expect(result.toArray()).toEqual([3, 4, 5]);
+    });
+
+    it('all scalars yields 0-d result', () => {
+      const a = arange(12).reshape([3, 4]);
+      const result = vindex(a, 1, 2);
+      expect(result.shape).toEqual([]);
+      expect(result.item()).toBe(6);
+    });
+
+    it('negative scalar index', () => {
+      const a = arange(15).reshape([5, 3]);
+      const result = vindex(a, -1);
+      expect(result.shape).toEqual([3]);
+      expect(result.toArray()).toEqual([12, 13, 14]);
+    });
+
+    it('string scalar index (e.g. "2") treated as number', () => {
+      const a = arange(15).reshape([5, 3]);
+      const r1 = vindex(a, 2);
+      const r2 = vindex(a, '2');
+      expect(r2.shape).toEqual(r1.shape);
+      expect(r2.toArray()).toEqual(r1.toArray());
+    });
+  });
+
+  // ========================================
+  // Integer array indexing
+  // ========================================
+  describe('integer array indexing', () => {
+    it('1-d index array — subspace first, trailing dims after', () => {
+      const a = arange(15).reshape([5, 3]);
+      const idx = array([1, 3, 0]);
+      const result = vindex(a, idx);
+      expect(result.shape).toEqual([3, 3]);
+      expect(result.toArray()).toEqual([
+        [3, 4, 5],
+        [9, 10, 11],
+        [0, 1, 2],
+      ]);
+    });
+
+    it('number[] is cast to index array', () => {
+      const a = arange(15).reshape([5, 3]);
+      const result = vindex(a, [1, 3, 0]);
+      expect(result.shape).toEqual([3, 3]);
+      expect(result.toArray()).toEqual([
+        [3, 4, 5],
+        [9, 10, 11],
+        [0, 1, 2],
+      ]);
+    });
+
+    it('two index arrays: both dims consumed, subspace remains', () => {
+      const a = arange(12).reshape([3, 4]);
+      const row = array([0, 1, 2]);
+      const col = array([1, 2, 3]);
+      const result = vindex(a, row, col);
+      expect(result.shape).toEqual([3]);
+      // a[0,1]=1, a[1,2]=6, a[2,3]=11
+      expect(result.toArray()).toEqual([1, 6, 11]);
+    });
+
+    it('index arrays broadcast together', () => {
+      const a = arange(12).reshape([3, 4]);
+      const row = array([[0], [1]]);   // shape (2,1)
+      const col = array([[0, 1, 2]]); // shape (1,3)
+      const result = vindex(a, row, col);
+      expect(result.shape).toEqual([2, 3]);
+      // a[0,0]=0, a[0,1]=1, a[0,2]=2
+      // a[1,0]=4, a[1,1]=5, a[1,2]=6
+      expect(result.toArray()).toEqual([
+        [0, 1, 2],
+        [4, 5, 6],
+      ]);
+    });
+
+    it('negative integer array indices', () => {
+      const a = arange(12).reshape([3, 4]);
+      const result = vindex(a, array([-1]));
+      expect(result.shape).toEqual([1, 4]);
+      expect(result.toArray()).toEqual([[8, 9, 10, 11]]);
+    });
+
+    it('out-of-bounds index throws', () => {
+      const a = arange(6).reshape([2, 3]);
+      expect(() => vindex(a, array([5]))).toThrow(/out of bounds/);
+    });
+  });
+
+  // ========================================
+  // Slice indexing
+  // ========================================
+  describe('slice string indices', () => {
+    it('":" keeps the dimension', () => {
+      const a = arange(15).reshape([5, 3]);
+      const result = vindex(a, ':', '1:3');
+      expect(result.shape).toEqual([5, 2]);
+    });
+
+    it('range slice selects a subset', () => {
+      const a = arange(12).reshape([3, 4]);
+      const result = vindex(a, '1:3', ':');
+      expect(result.shape).toEqual([2, 4]);
+      expect(result.toArray()).toEqual([
+        [4, 5, 6, 7],
+        [8, 9, 10, 11],
+      ]);
+    });
+  });
+
+  // ========================================
+  // Ellipsis
+  // ========================================
+  describe('ellipsis', () => {
+    it('... expands to fill missing dims', () => {
+      const a = arange(24).reshape([2, 3, 4]);
+      const idx = array([0, 2]);
+      // vindex(a, '...', idx): idx indexes last dim, '...' fills first two
+      const result = vindex(a, '...', idx);
+      expect(result.shape).toEqual([2, 2, 3]);
+    });
+
+    it('ellipsis at start', () => {
+      const a = arange(24).reshape([2, 3, 4]);
+      const idx = array([1, 2]);
+      const result = vindex(a, '...', idx);
+      // idx covers axis 2; '...' covers axes 0 and 1
+      expect(result.shape).toEqual([2, 2, 3]);
+    });
+
+    it('more than one ellipsis throws', () => {
+      const a = arange(6).reshape([2, 3]);
+      expect(() => vindex(a, '...', '...')).toThrow(/ellipsis/);
+    });
+  });
+
+  // ========================================
+  // Mixed advanced + slice (dask ordering)
+  // ========================================
+  describe('mixed integer array + slice (dask ordering)', () => {
+    it('subspace dims precede slice dims', () => {
+      const a = arange(30).reshape([5, 6]);
+      const idx = array([1, 3]);
+      // vindex(a, idx, ':'): row selected by idx, all columns retained
+      const result = vindex(a, idx, ':');
+      // dask: subspace (2,) first, then slice dim (6,) → shape (2, 6)
+      expect(result.shape).toEqual([2, 6]);
+      expect(result.toArray()).toEqual([
+        [6, 7, 8, 9, 10, 11],
+        [18, 19, 20, 21, 22, 23],
+      ]);
+    });
+
+    it('2D index + slice → subspace shape then slice shape', () => {
+      const a = arange(24).reshape([4, 6]);
+      const idx = array([[0, 2], [1, 3]]); // shape (2, 2)
+      const result = vindex(a, idx, ':');
+      // subspace (2,2), slice (6,) → (2, 2, 6)
+      expect(result.shape).toEqual([2, 2, 6]);
+    });
+
+    it('slice + integer array: slice comes after subspace', () => {
+      const a = arange(24).reshape([4, 6]);
+      const idx = array([0, 2]);
+      const result = vindex(a, '1:3', idx);
+      // idx indexes axis 1 (advanced); '1:3' is a range slice for axis 0
+      // dask ordering: subspace (2,) first, then slice dim (2,) → (2, 2)
+      // result[advIdx, sliceIdx] = a[1+sliceIdx, idx[advIdx]]
+      expect(result.shape).toEqual([2, 2]);
+      expect(result.toArray()).toEqual([
+        [a.get([1, 0]), a.get([2, 0])],  // idx[0]=0: col 0, rows 1 and 2
+        [a.get([1, 2]), a.get([2, 2])],  // idx[1]=2: col 2, rows 1 and 2
+      ]);
+    });
+  });
+
+  // ========================================
+  // Edge cases
+  // ========================================
+  describe('edge cases', () => {
+    it('1D array, scalar → 0-d result', () => {
+      const a = array([10, 20, 30, 40]);
+      const result = vindex(a, 2);
+      expect(result.shape).toEqual([]);
+      expect(result.item()).toBe(30);
+    });
+
+    it('all-slice with ellipsis is identity', () => {
+      const a = arange(6).reshape([2, 3]);
+      const result = vindex(a, '...', ':');
+      expect(result.shape).toEqual([2, 3]);
+      expect(result.toArray()).toEqual(a.toArray());
+    });
+
+    it('preserves dtype', () => {
+      const a = array([1.5, 2.5, 3.5], 'float32');
+      const result = vindex(a, array([0, 2]));
+      expect(result.dtype).toBe('float32');
+      expect(result.toArray()).toEqual([1.5, 3.5]);
+    });
+  });
+
+  // ========================================
+  // Complex dtypes
+  // ========================================
+  describe('complex dtypes', () => {
+    it('preserves complex128 dtype', () => {
+      const a = array([new Complex(1, 2), new Complex(3, 4), new Complex(5, 6)]);
+      const result = vindex(a, array([2, 0]));
+      expect(result.dtype).toBe('complex128');
+      expect(result.shape).toEqual([2]);
+      const vals = result.toArray() as Complex[];
+      expect(vals[0]!.re).toBe(5);
+      expect(vals[0]!.im).toBe(6);
+      expect(vals[1]!.re).toBe(1);
+      expect(vals[1]!.im).toBe(2);
+    });
+
+    it('scalar index on complex128 2D array removes dimension', () => {
+      const a = array([
+        [new Complex(1, 0), new Complex(0, 1)],
+        [new Complex(2, 0), new Complex(0, 2)],
+        [new Complex(3, 0), new Complex(0, 3)],
+      ]);
+      const result = vindex(a, 1);
+      expect(result.dtype).toBe('complex128');
+      expect(result.shape).toEqual([2]);
+      const vals = result.toArray() as Complex[];
+      expect(vals[0]!.re).toBe(2);
+      expect(vals[0]!.im).toBe(0);
+      expect(vals[1]!.re).toBe(0);
+      expect(vals[1]!.im).toBe(2);
+    });
+
+    it('integer array index on complex64 array', () => {
+      const a = array([new Complex(1, 1), new Complex(2, 2), new Complex(3, 3)], 'complex64');
+      const result = vindex(a, array([0, 2, 1]));
+      expect(result.dtype).toBe('complex64');
+      expect(result.shape).toEqual([3]);
+      const vals = result.toArray() as Complex[];
+      expect(vals[0]!.re).toBeCloseTo(1);
+      expect(vals[1]!.re).toBeCloseTo(3);
+      expect(vals[2]!.re).toBeCloseTo(2);
+    });
+
+    it('slice on complex128 array', () => {
+      const a = array([new Complex(1, 2), new Complex(3, 4), new Complex(5, 6), new Complex(7, 8)]);
+      const result = vindex(a, '1:3');
+      expect(result.dtype).toBe('complex128');
+      expect(result.shape).toEqual([2]);
+      const vals = result.toArray() as Complex[];
+      expect(vals[0]!.re).toBe(3);
+      expect(vals[0]!.im).toBe(4);
+      expect(vals[1]!.re).toBe(5);
+      expect(vals[1]!.im).toBe(6);
+    });
+  });
+});

--- a/tests/unit/vindex.test.ts
+++ b/tests/unit/vindex.test.ts
@@ -218,6 +218,59 @@ describe('vindex', () => {
   });
 
   // ========================================
+  // newaxis
+  // ========================================
+  describe('newaxis', () => {
+    it('slice: newaxis at start inserts leading dim', () => {
+      const a = arange(6).reshape([2, 3]);
+      const result = vindex(a, 'newaxis', ':', ':');
+      expect(result.shape).toEqual([1, 2, 3]);
+      expect(result.toArray()).toEqual([[[0, 1, 2], [3, 4, 5]]]);
+    });
+
+    it('slice: newaxis between dims', () => {
+      const a = arange(6).reshape([2, 3]);
+      const result = vindex(a, ':', 'newaxis', ':');
+      expect(result.shape).toEqual([2, 1, 3]);
+    });
+
+    it('slice: newaxis at end', () => {
+      const a = arange(4);
+      const result = vindex(a, ':', 'newaxis');
+      expect(result.shape).toEqual([4, 1]);
+    });
+
+    it('array index + newaxis: newaxis appears after subspace', () => {
+      const a = arange(15).reshape([5, 3]);
+      const idx = array([1, 3]);
+      const result = vindex(a, idx, 'newaxis', ':');
+      // subspace (2,), newaxis (1,), slice (3,) → (2, 1, 3)
+      expect(result.shape).toEqual([2, 1, 3]);
+      expect(result.toArray()).toEqual([[[3, 4, 5]], [[9, 10, 11]]]);
+    });
+
+    it('newaxis before array index: still appears after subspace', () => {
+      const a = arange(15).reshape([5, 3]);
+      const idx = array([1, 3]);
+      const result = vindex(a, 'newaxis', idx, ':');
+      // newaxis is in slice portion position 0 → after subspace (2,)
+      expect(result.shape).toEqual([2, 1, 3]);
+    });
+
+    it('multiple newaxis entries', () => {
+      const a = arange(6);
+      const result = vindex(a, 'newaxis', ':', 'newaxis');
+      expect(result.shape).toEqual([1, 6, 1]);
+    });
+
+    it('single newaxis on 1D array', () => {
+      const a = arange(3);
+      expect(vindex(a, 'newaxis').shape).toEqual([1, 3]);
+      expect(vindex(a, 'newaxis').toArray()).toEqual([[0, 1, 2]]);
+    });
+  });
+
+  // ========================================
   // Complex dtypes
   // ========================================
   describe('complex dtypes', () => {

--- a/tests/validation/exports.numpy.test.ts
+++ b/tests/validation/exports.numpy.test.ts
@@ -288,6 +288,7 @@ describe('NumPy API Comparison', () => {
         // Convenience indexing functions
         'iindex',
         'bindex',
+        'vindex',
         // NDArray utility methods exported as standalone
         'fill',
         'item',
@@ -469,6 +470,7 @@ describe('NumPy API Comparison', () => {
         'moveaxis',
         'iindex',
         'bindex',
+        'vindex',
         'inner',
         'outer',
         'tensordot',


### PR DESCRIPTION
This is a slightly more extensive change build off of https://github.com/dupontcyborg/numpy-ts/pull/62.

It adds:
* `...` and `newaxis` are supported in slice operations. They work like `...` and `np.newaxis`/`None` in numpy.
* `vindex()`, which supports proper multidimensional indexing like numpy. 

Note that the conventions of vindex differ slightly from numpy's. Numpy's ordering of dimension differs depending on wether the indexing dimensions are all contiguous. I'm not too opinionated over whether to implement dask's convention or numpys. Dasks is more consistent, while numpy's is often more intuitive for realistic use cases.