### PR TITLE
Made [Symbol.dispose] non-optional with a built-in polyfill for old runtimes (...and Safari...)

### DIFF
--- a/docs/v1.3.x/guides/memory-management.mdx
+++ b/docs/v1.3.x/guides/memory-management.mdx
@@ -49,7 +49,7 @@ You generally **don't** need it for:
 
 ### `Symbol.dispose` and the `using` keyword
 
-On runtimes that support `Symbol.dispose` (Node 22+, Chrome 134+, Firefox 132+), arrays implement `[Symbol.dispose]`, enabling the `using` keyword for automatic scope-based cleanup:
+All arrays implement `[Symbol.dispose]`, enabling the `using` keyword for automatic scope-based cleanup:
 
 ```ts
 {
@@ -66,7 +66,7 @@ for (let i = 0; i < 1000; i++) {
 ```
 
 <Note>
-**Safari compatibility:** Safari does not yet support `Symbol.dispose`. The `using` keyword is therefore unavailable on Safari, but `.dispose()` itself works identically across all runtimes. For cross-browser code, prefer calling `.dispose()` directly.
+**Browser compatibility:** The `using` keyword requires either native runtime support (Node 22+, Chrome 134+, Firefox 132+) or a transpiler that downlevels `using` (TypeScript, esbuild, Babel, SWC). On runtimes without native `Symbol.dispose` (e.g. Safari), numpy-ts installs a polyfill using the same `Symbol.for("Symbol.dispose")` key that these transpilers emit, so transpiled `using` statements work correctly everywhere. You can also call `.dispose()` directly on any runtime.
 </Note>
 
 ## `configureWasm()` — pool sizing

--- a/scripts/generate-full.ts
+++ b/scripts/generate-full.ts
@@ -439,7 +439,7 @@ export { Complex } from '../common/complex';
   output.push('');
   output.push('// WASM configuration');
   output.push(`export { wasmConfig } from '../common/wasm/config';`);
-  output.push(`export { configureWasm } from '../common/wasm/runtime';`);
+  output.push(`export { configureWasm, wasmFreeBytes } from '../common/wasm/runtime';`);
   output.push('');
   output.push('// Runtime capabilities');
   output.push(`export { hasFloat16 } from '../common/dtype';`);

--- a/src/common/ndarray-core.ts
+++ b/src/common/ndarray-core.ts
@@ -608,16 +608,15 @@ export class NDArrayCore {
    * garbage collected. Call dispose() to free immediately in tight loops,
    * benchmarks, or resource-sensitive contexts.
    *
-   * Also available as `[Symbol.dispose]` on supported runtimes, enabling
-   * the `using` keyword for automatic scope-based cleanup:
+   * Also available as `[Symbol.dispose]`, enabling the `using` keyword for
+   * automatic scope-based cleanup (requires native `using` support or a
+   * transpiler such as TypeScript, esbuild, Babel, or SWC):
    * ```ts
    * {
    *   using result = np.add(a, b);
    *   // use result...
    * } // automatically freed here
    * ```
-   * Safari does not yet support `Symbol.dispose` — use `.dispose()` directly
-   * for cross-browser compatibility.
    */
   dispose(): void {
     this._storage.dispose();
@@ -642,15 +641,9 @@ export class NDArrayCore {
     }
     return this.get(args);
   }
-  // Symbol.dispose declaration for TypeScript (conditionally defined below)
-  [Symbol.dispose]?: () => void;
-}
-
-// Symbol.dispose support for the `using` keyword (automatic scope-based cleanup).
-// Safari does not yet support Symbol.dispose, so we define it conditionally.
-// Users on Safari can call .dispose() directly instead.
-if (typeof Symbol.dispose !== 'undefined') {
-  NDArrayCore.prototype[Symbol.dispose] = NDArrayCore.prototype.dispose;
+  [Symbol.dispose](): void {
+    this.dispose();
+  }
 }
 
 // Re-export types

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -26,6 +26,7 @@ import {
 // Polyfill Symbol.dispose for runtimes that don't define it natively (e.g. Safari).
 // Uses the same Symbol.for key that TypeScript, esbuild, Babel, and SWC emit in
 // their downlevel helpers, so `using` works correctly through any transpiler.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Symbol.dispose is readonly in TS lib
 (Symbol as any).dispose ??= Symbol.for('Symbol.dispose');
 
 /**
@@ -649,7 +650,6 @@ export class ArrayStorage {
     return strides;
   }
 }
-
 
 /**
  * Compute strides for a given shape (row-major order)

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -23,6 +23,11 @@ import {
   unregisterCleanup,
 } from './wasm/runtime';
 
+// Polyfill Symbol.dispose for runtimes that don't define it natively (e.g. Safari).
+// Uses the same Symbol.for key that TypeScript, esbuild, Babel, and SWC emit in
+// their downlevel helpers, so `using` works correctly through any transpiler.
+(Symbol as any).dispose ??= Symbol.for('Symbol.dispose');
+
 /**
  * Maximum number of dimensions an array can have (matches NumPy's limit).
  */
@@ -33,8 +38,9 @@ export const MAX_NDIM = 64;
  * Manages the underlying TypedArray and metadata
  */
 export class ArrayStorage {
-  // Symbol.dispose for `using` keyword support (conditionally defined below class)
-  [Symbol.dispose]?: () => void;
+  [Symbol.dispose](): void {
+    this.dispose();
+  }
 
   // Underlying TypedArray data buffer
   private _data: TypedArray;
@@ -134,10 +140,9 @@ export class ArrayStorage {
    * when you know this storage will not be used again — useful in tight loops,
    * benchmarks, or resource-sensitive contexts.
    *
-   * Also available as `[Symbol.dispose]` on runtimes that support it (Node 18+,
-   * Chrome 134+, Firefox 132+), enabling the `using` keyword for automatic
-   * scope-based cleanup. Safari does not yet support `Symbol.dispose`, so use
-   * this method directly for cross-browser compatibility.
+   * Also available as `[Symbol.dispose]`, enabling the `using` keyword for
+   * automatic scope-based cleanup (requires native `using` support or a
+   * transpiler such as TypeScript, esbuild, Babel, or SWC).
    */
   dispose(): void {
     if (this._wasmRegion) {
@@ -645,12 +650,6 @@ export class ArrayStorage {
   }
 }
 
-// Symbol.dispose support for the `using` keyword (automatic scope-based cleanup).
-// Safari does not yet support Symbol.dispose, so we define it conditionally.
-// Users on Safari can call .dispose() directly instead.
-if (typeof Symbol.dispose !== 'undefined') {
-  ArrayStorage.prototype[Symbol.dispose] = ArrayStorage.prototype.dispose;
-}
 
 /**
  * Compute strides for a given shape (row-major order)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -466,7 +466,7 @@ export { serializeTxt, type SerializeTxtOptions } from '../io/txt/serializer';
 
 // WASM configuration
 export { wasmConfig } from '../common/wasm/config';
-export { configureWasm } from '../common/wasm/runtime';
+export { configureWasm, wasmFreeBytes } from '../common/wasm/runtime';
 
 // Runtime capabilities
 export { hasFloat16 } from '../common/dtype';

--- a/src/full/index.ts
+++ b/src/full/index.ts
@@ -1941,7 +1941,7 @@ export {
 
 // WASM configuration
 export { wasmConfig } from '../common/wasm/config';
-export { configureWasm } from '../common/wasm/runtime';
+export { configureWasm, wasmFreeBytes } from '../common/wasm/runtime';
 
 // Runtime capabilities
 export { hasFloat16 } from '../common/dtype';

--- a/src/index.ts
+++ b/src/index.ts
@@ -561,7 +561,7 @@ export type { SerializeTxtOptions } from './io/txt/serializer';
 
 // WASM configuration (for testing — set thresholdMultiplier to 0 to force WASM, Infinity to disable)
 export { wasmConfig } from './common/wasm/config';
-export { configureWasm } from './common/wasm/runtime';
+export { configureWasm, wasmFreeBytes } from './common/wasm/runtime';
 
 // Serializers - re-export directly (they accept NDArrayCore, and NDArray extends NDArrayCore)
 export { serializeNpy } from './io/npy/serializer';

--- a/tests/bundles/browser-dispose-bundled.test.ts
+++ b/tests/bundles/browser-dispose-bundled.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Browser dispose-protocol test — bundled path
+ *
+ * Tests the real end-to-end user path: user writes `using arr = np.zeros(...)`,
+ * a bundler (esbuild/rollup/webpack) transpiles `using` to a helper that looks
+ * up Symbol.dispose, and the polyfill ensures the helper finds the method.
+ *
+ * Architecture:
+ *   1. The tree-shaking project (groupOrder 2) builds browser-targeted bundles
+ *      from dispose-using-browser.ts with each bundler (target: es2020).
+ *   2. This test (groupOrder 3) loads those pre-built bundles in Playwright
+ *      and calls run() to verify the dispose protocol works.
+ *
+ * This file contains ZERO `using` syntax — it is safe to load in WebKit,
+ * which cannot parse `using`. The `using` keyword only exists inside the
+ * pre-built bundles where it has been transpiled to helper code.
+ *
+ * Test matrix covered:
+ *   esbuild  × Chromium, Firefox, WebKit
+ *   Rollup   × Chromium, Firefox, WebKit
+ *   Webpack  × Chromium, Firefox, WebKit
+ */
+
+import { describe, test, expect } from 'vitest';
+
+const BUNDLERS = [
+  { name: 'esbuild', path: '/tests/tree-shaking/.output/dispose/browser/esbuild.mjs' },
+  { name: 'Rollup', path: '/tests/tree-shaking/.output/dispose/browser/rollup.mjs' },
+  { name: 'Webpack', path: '/tests/tree-shaking/.output/dispose/browser/webpack/bundle.mjs' },
+] as const;
+
+describe.each(BUNDLERS)('$name dispose in browser', ({ name, path }) => {
+  test(`${name}: run() passes (using + wasmFreeBytes lifecycle)`, async () => {
+    const mod = await import(/* @vite-ignore */ path);
+    const result = mod.run();
+
+    expect(result.passed, `${name}: ${result.error}`).toBe(true);
+    expect(result.leak, `${name}: leaked ${result.leak} bytes`).toBe(0);
+  });
+});

--- a/tests/bundles/browser-dispose.test.ts
+++ b/tests/bundles/browser-dispose.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Browser dispose-protocol test — vanilla path (no bundler/transpiler)
+ *
+ * Tests native `using` support directly in the browser, importing the
+ * browser bundle without any transpilation. This validates that runtimes
+ * with native `using` support can use the dispose protocol out of the box.
+ *
+ * This file uses raw `using` syntax, so it CANNOT run on WebKit (Safari),
+ * which doesn't parse `using`. It runs only on Chromium and Firefox via
+ * the browser-dispose-vanilla vitest project.
+ *
+ * Memory assertions follow the wasm-leaks pattern: warmup first, then
+ * measure over N iterations so allocator overhead washes out.
+ *
+ * Test matrix covered:
+ *   vanilla (no transpiler) × Chromium, Firefox
+ */
+
+import { describe, test, expect, beforeAll } from 'vitest';
+
+let np: any;
+const ITERS = 10;
+const SIZE = 10_000;
+
+describe('vanilla dispose protocol (native using)', () => {
+  beforeAll(async () => {
+    np = await import('/dist/numpy-ts.browser.js');
+    // Warmup: absorb one-time WASM heap initialization costs for each op.
+    for (let i = 0; i < 3; i++) {
+      np.zeros([SIZE]).dispose();
+      np.ones([SIZE]).dispose();
+      np.arange(SIZE).dispose();
+    }
+  });
+
+  test('Symbol.dispose is defined (native)', () => {
+    expect(typeof Symbol.dispose).toBe('symbol');
+  });
+
+  test('using: single array frees memory each iteration', () => {
+    const before = np.wasmFreeBytes();
+
+    for (let i = 0; i < ITERS; i++) {
+      using arr = np.zeros([SIZE]);
+      expect(arr.size).toBe(SIZE);
+      expect(np.wasmFreeBytes()).toBeLessThan(before);
+    }
+
+    const leak = before - np.wasmFreeBytes();
+    expect(leak / ITERS, `leaks ${leak} bytes over ${ITERS} iters`).toBe(0);
+  });
+
+  test('using: multiple arrays freed each iteration', () => {
+    // Absorb fixed allocator fragmentation from interleaving sizes
+    /* eslint-disable @typescript-eslint/no-unused-vars -- using vars exist for dispose side-effect */
+    {
+      using a = np.zeros([SIZE]);
+      using b = np.ones([SIZE]);
+      using c = np.arange(SIZE);
+    }
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+
+    const before = np.wasmFreeBytes();
+
+    for (let i = 0; i < ITERS; i++) {
+      using a = np.zeros([SIZE]);
+      using b = np.ones([SIZE]);
+      using c = np.arange(SIZE);
+      expect(a.size).toBe(SIZE);
+      expect(b.size).toBe(SIZE);
+      expect(c.size).toBe(SIZE);
+      expect(np.wasmFreeBytes()).toBeLessThan(before);
+    }
+
+    const leak = before - np.wasmFreeBytes();
+    expect(leak / ITERS, `leaks ${leak} bytes over ${ITERS} iters`).toBe(0);
+  });
+
+  test('using: nested blocks dispose inner before outer', () => {
+    // Absorb fixed allocator fragmentation
+    /* eslint-disable @typescript-eslint/no-unused-vars -- using vars exist for dispose side-effect */
+    {
+      using a = np.zeros([SIZE]);
+      using b = np.ones([SIZE]);
+    }
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+
+    const before = np.wasmFreeBytes();
+
+    for (let i = 0; i < ITERS; i++) {
+      using outer = np.zeros([SIZE]);
+      const afterOuter = np.wasmFreeBytes();
+
+      {
+        using inner = np.ones([SIZE]);
+        expect(np.wasmFreeBytes()).toBeLessThan(afterOuter);
+        expect(inner.size).toBe(SIZE);
+      }
+
+      expect(np.wasmFreeBytes()).toBeLessThan(before);
+      expect(outer.size).toBe(SIZE);
+    }
+
+    const leak = before - np.wasmFreeBytes();
+    expect(leak / ITERS, `leaks ${leak} bytes over ${ITERS} iters`).toBe(0);
+  });
+});

--- a/tests/tree-shaking/dispose-protocol.test.ts
+++ b/tests/tree-shaking/dispose-protocol.test.ts
@@ -21,7 +21,7 @@ import webpack from 'webpack';
 import { mkdir, readFile, stat } from 'fs/promises';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 import { NUMPY_TS_ESM, NUMPY_TS_CORE } from './shared';
 
@@ -35,7 +35,7 @@ const NUMPY_TS_BROWSER = resolve(__dirname, '../../dist/numpy-ts.browser.js');
 
 /** Run a bundled JS file with Node and return stdout. Throws on non-zero exit. */
 function execBundle(file: string): string {
-  return execSync(`node ${file}`, {
+  return execFileSync('node', [file], {
     encoding: 'utf-8',
     timeout: 15000,
     env: { ...process.env, NODE_NO_WARNINGS: '1' },

--- a/tests/tree-shaking/dispose-protocol.test.ts
+++ b/tests/tree-shaking/dispose-protocol.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Bundler dispose-protocol tests
+ *
+ * Verifies that the Symbol.dispose polyfill survives tree-shaking and that
+ * transpiled `using` statements work correctly through esbuild, Rollup, and
+ * Webpack. Each bundler builds the dispose-using fixture with a downlevel
+ * target (ES2020, which lacks native `using`), then we execute the bundle
+ * and assert it exits cleanly.
+ *
+ * A failure here reproduces the Safari "JS object not disposable" bug that
+ * occurs when the polyfill is missing and a transpiled helper can't find
+ * [Symbol.dispose].
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { build as esbuildBuild } from 'esbuild';
+import { rollup } from 'rollup';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import alias from '@rollup/plugin-alias';
+import webpack from 'webpack';
+import { mkdir, readFile, stat } from 'fs/promises';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+import { NUMPY_TS_ESM, NUMPY_TS_CORE } from './shared';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FIXTURE = resolve(__dirname, 'fixtures/dispose-using.ts');
+const BROWSER_FIXTURE = resolve(__dirname, 'fixtures/dispose-using-browser.ts');
+const OUT_DIR = resolve(__dirname, '.output/dispose');
+const BROWSER_OUT_DIR = resolve(__dirname, '.output/dispose/browser');
+const NUMPY_TS_BROWSER = resolve(__dirname, '../../dist/numpy-ts.browser.js');
+
+/** Run a bundled JS file with Node and return stdout. Throws on non-zero exit. */
+function execBundle(file: string): string {
+  return execSync(`node ${file}`, {
+    encoding: 'utf-8',
+    timeout: 15000,
+    env: { ...process.env, NODE_NO_WARNINGS: '1' },
+  }).trim();
+}
+
+describe('esbuild dispose protocol', () => {
+  const outfile = resolve(OUT_DIR, 'esbuild-dispose.mjs');
+
+  beforeAll(async () => {
+    await mkdir(resolve(OUT_DIR), { recursive: true });
+  });
+
+  it('builds dispose-using fixture with downlevel target', async () => {
+    await esbuildBuild({
+      entryPoints: [FIXTURE],
+      bundle: true,
+      platform: 'node',
+      format: 'esm',
+      // ES2020 forces `using` to be downleveled — the helper will look up
+      // Symbol.dispose || Symbol.for("Symbol.dispose").
+      target: 'es2020',
+      outfile,
+      write: true,
+      alias: {
+        'numpy-ts/core': NUMPY_TS_CORE,
+        'numpy-ts': NUMPY_TS_ESM,
+      },
+    });
+
+    const s = await stat(outfile);
+    expect(s.size).toBeGreaterThan(0);
+  }, 60000);
+
+  it('bundled output executes without "not disposable" error', () => {
+    const out = execBundle(outfile);
+    expect(out).toContain('PASS');
+  });
+
+  it('bundle contains the polyfill', async () => {
+    const code = await readFile(outfile, 'utf-8');
+    expect(code).toContain('Symbol.dispose');
+  });
+
+  it('bundle does not contain raw `using` declarations', async () => {
+    const code = await readFile(outfile, 'utf-8');
+    expect(code).not.toMatch(/\busing\s+\w+\s*=/);
+  });
+});
+
+describe('Rollup dispose protocol', () => {
+  const preTranspiled = resolve(OUT_DIR, 'rollup-dispose-pre.mjs');
+  const outfile = resolve(OUT_DIR, 'rollup-dispose.mjs');
+
+  beforeAll(async () => {
+    await mkdir(resolve(OUT_DIR), { recursive: true });
+  });
+
+  it('builds dispose-using fixture with downlevel target', async () => {
+    // Step 1: Pre-transpile the TS fixture to ES2020 JS with esbuild.
+    // @rollup/plugin-typescript cannot downlevel `using` reliably, but
+    // esbuild can. This mirrors real-world setups where Rollup delegates
+    // transpilation to esbuild.
+    await esbuildBuild({
+      entryPoints: [FIXTURE],
+      bundle: false,
+      platform: 'node',
+      format: 'esm',
+      target: 'es2020',
+      outfile: preTranspiled,
+      write: true,
+    });
+
+    // Step 2: Bundle the pre-transpiled JS with Rollup.
+    const bundle = await rollup({
+      input: preTranspiled,
+      plugins: [
+        alias({
+          entries: [
+            { find: 'numpy-ts/core', replacement: NUMPY_TS_CORE },
+            { find: 'numpy-ts', replacement: NUMPY_TS_ESM },
+          ],
+        }),
+        nodeResolve({ extensions: ['.mjs', '.js'] }),
+      ],
+      treeshake: {
+        moduleSideEffects: true,
+      },
+      onwarn: (warning, warn) => {
+        if (warning.code === 'CIRCULAR_DEPENDENCY') return;
+        warn(warning);
+      },
+    });
+
+    await bundle.write({ file: outfile, format: 'esm' });
+    await bundle.close();
+
+    const s = await stat(outfile);
+    expect(s.size).toBeGreaterThan(0);
+  }, 120000);
+
+  it('bundled output executes without "not disposable" error', () => {
+    const out = execBundle(outfile);
+    expect(out).toContain('PASS');
+  });
+
+  it('bundle contains the polyfill', async () => {
+    const code = await readFile(outfile, 'utf-8');
+    expect(code).toContain('Symbol.dispose');
+  });
+
+  it('bundle does not contain raw `using` declarations', async () => {
+    const code = await readFile(outfile, 'utf-8');
+    expect(code).not.toMatch(/\busing\s+\w+\s*=/);
+  });
+});
+
+describe('Webpack dispose protocol', () => {
+  const outDir = resolve(OUT_DIR, 'webpack-dispose');
+  const outfile = resolve(outDir, 'bundle.mjs');
+
+  beforeAll(async () => {
+    await mkdir(outDir, { recursive: true });
+  });
+
+  it('builds dispose-using fixture with downlevel target', async () => {
+    await new Promise<void>((resolveP, reject) => {
+      webpack(
+        {
+          entry: FIXTURE,
+          mode: 'production',
+          output: {
+            path: outDir,
+            filename: 'bundle.mjs',
+            library: { type: 'module' },
+          },
+          experiments: { outputModule: true },
+          target: 'es2020',
+          resolve: {
+            extensions: ['.ts', '.js'],
+            alias: {
+              'numpy-ts/core': NUMPY_TS_CORE,
+              'numpy-ts': NUMPY_TS_ESM,
+            },
+          },
+          module: {
+            rules: [
+              {
+                test: /\.ts$/,
+                use: {
+                  loader: 'ts-loader',
+                  options: {
+                    configFile: resolve(__dirname, '../../tsconfig.json'),
+                    compilerOptions: {
+                      declaration: false,
+                      declarationMap: false,
+                      sourceMap: false,
+                      target: 'ES2020',
+                    },
+                    transpileOnly: true,
+                  },
+                },
+                exclude: /node_modules/,
+              },
+              {
+                test: /\.js$/,
+                resolve: { fullySpecified: false },
+              },
+            ],
+          },
+          externals: [/^node:/],
+          optimization: {
+            usedExports: true,
+            sideEffects: true,
+            minimize: false,
+          },
+        },
+        (err, stats) => {
+          if (err) reject(err);
+          else if (stats?.hasErrors()) {
+            const info = stats.toJson();
+            reject(new Error(info.errors?.map((e) => e.message).join('\n') || 'Build failed'));
+          } else resolveP();
+        }
+      );
+    });
+
+    const s = await stat(outfile);
+    expect(s.size).toBeGreaterThan(0);
+  }, 120000);
+
+  it('bundled output executes without "not disposable" error', () => {
+    const out = execBundle(outfile);
+    expect(out).toContain('PASS');
+  });
+
+  it('bundle contains the polyfill', async () => {
+    const code = await readFile(outfile, 'utf-8');
+    expect(code).toContain('Symbol.dispose');
+  });
+
+  it('bundle does not contain raw `using` declarations', async () => {
+    const code = await readFile(outfile, 'utf-8');
+    expect(code).not.toMatch(/\busing\s+\w+\s*=/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Browser-targeted builds
+//
+// These bundles are consumed by the browser-dispose vitest project (Playwright).
+// They use the browser fixture (exports run()) and alias numpy-ts to the
+// browser bundle so WASM loading works in browser environments.
+// ---------------------------------------------------------------------------
+
+describe('browser builds', () => {
+  beforeAll(async () => {
+    await mkdir(BROWSER_OUT_DIR, { recursive: true });
+  });
+
+  describe('esbuild browser build', () => {
+    const browserOutfile = resolve(BROWSER_OUT_DIR, 'esbuild.mjs');
+
+    it('builds browser fixture with downlevel target', async () => {
+      await esbuildBuild({
+        entryPoints: [BROWSER_FIXTURE],
+        bundle: true,
+        platform: 'browser',
+        format: 'esm',
+        target: 'es2020',
+        outfile: browserOutfile,
+        write: true,
+        external: ['node:fs', 'node:fs/promises', 'node:module'],
+        alias: {
+          'numpy-ts/core': NUMPY_TS_BROWSER,
+          'numpy-ts': NUMPY_TS_BROWSER,
+        },
+      });
+
+      const s = await stat(browserOutfile);
+      expect(s.size).toBeGreaterThan(0);
+    }, 60000);
+
+    it('exports run() that passes on Node', async () => {
+      const mod = await import(browserOutfile);
+      const result = mod.run();
+      expect(result.passed, result.error).toBe(true);
+      expect(result.leak).toBe(0);
+    });
+
+    it('no raw using in bundle', async () => {
+      const code = await readFile(browserOutfile, 'utf-8');
+      expect(code).not.toMatch(/\busing\s+\w+\s*=/);
+    });
+  });
+
+  describe('Rollup browser build', () => {
+    // @rollup/plugin-typescript does not downlevel `using` (confirmed bug).
+    // Real Rollup users use rollup-plugin-esbuild instead — our pre-transpile
+    // approach is functionally equivalent.
+    const browserPreTranspiled = resolve(BROWSER_OUT_DIR, 'rollup-pre.mjs');
+    const browserOutfile = resolve(BROWSER_OUT_DIR, 'rollup.mjs');
+
+    it('builds browser fixture with downlevel target', async () => {
+      await esbuildBuild({
+        entryPoints: [BROWSER_FIXTURE],
+        bundle: false,
+        platform: 'browser',
+        format: 'esm',
+        target: 'es2020',
+        outfile: browserPreTranspiled,
+        write: true,
+      });
+
+      const bundle = await rollup({
+        input: browserPreTranspiled,
+        plugins: [
+          alias({
+            entries: [
+              { find: 'numpy-ts/core', replacement: NUMPY_TS_BROWSER },
+              { find: 'numpy-ts', replacement: NUMPY_TS_BROWSER },
+            ],
+          }),
+          nodeResolve({ extensions: ['.mjs', '.js'] }),
+        ],
+        treeshake: { moduleSideEffects: true },
+        onwarn: (warning, warn) => {
+          if (warning.code === 'CIRCULAR_DEPENDENCY') return;
+          warn(warning);
+        },
+      });
+
+      await bundle.write({ file: browserOutfile, format: 'esm' });
+      await bundle.close();
+
+      const s = await stat(browserOutfile);
+      expect(s.size).toBeGreaterThan(0);
+    }, 120000);
+
+    it('exports run() that passes on Node', async () => {
+      const mod = await import(browserOutfile);
+      const result = mod.run();
+      expect(result.passed, result.error).toBe(true);
+      expect(result.leak).toBe(0);
+    });
+
+    it('no raw using in bundle', async () => {
+      const code = await readFile(browserOutfile, 'utf-8');
+      expect(code).not.toMatch(/\busing\s+\w+\s*=/);
+    });
+  });
+
+  describe('Webpack browser build', () => {
+    const webpackBrowserDir = resolve(BROWSER_OUT_DIR, 'webpack');
+    const browserOutfile = resolve(webpackBrowserDir, 'bundle.mjs');
+
+    it('builds browser fixture with downlevel target', async () => {
+      await mkdir(webpackBrowserDir, { recursive: true });
+
+      await new Promise<void>((resolveP, reject) => {
+        webpack(
+          {
+            entry: BROWSER_FIXTURE,
+            mode: 'production',
+            output: {
+              path: webpackBrowserDir,
+              filename: 'bundle.mjs',
+              library: { type: 'module' },
+            },
+            experiments: { outputModule: true },
+            target: ['web', 'es2020'],
+            resolve: {
+              extensions: ['.ts', '.js'],
+              alias: {
+                'numpy-ts/core': NUMPY_TS_BROWSER,
+                'numpy-ts': NUMPY_TS_BROWSER,
+              },
+            },
+            module: {
+              rules: [
+                {
+                  test: /\.ts$/,
+                  use: {
+                    loader: 'ts-loader',
+                    options: {
+                      configFile: resolve(__dirname, '../../tsconfig.json'),
+                      compilerOptions: {
+                        declaration: false,
+                        declarationMap: false,
+                        sourceMap: false,
+                        target: 'ES2020',
+                      },
+                      transpileOnly: true,
+                    },
+                  },
+                  exclude: /node_modules/,
+                },
+                {
+                  test: /\.js$/,
+                  resolve: { fullySpecified: false },
+                },
+              ],
+            },
+            externals: [/^node:/],
+            optimization: {
+              usedExports: true,
+              sideEffects: true,
+              minimize: false,
+            },
+          },
+          (err, stats) => {
+            if (err) reject(err);
+            else if (stats?.hasErrors()) {
+              const info = stats.toJson();
+              reject(new Error(info.errors?.map((e) => e.message).join('\n') || 'Build failed'));
+            } else resolveP();
+          }
+        );
+      });
+
+      const s = await stat(browserOutfile);
+      expect(s.size).toBeGreaterThan(0);
+    }, 120000);
+
+    it('exports run() that passes on Node', async () => {
+      const mod = await import(browserOutfile);
+      const result = mod.run();
+      expect(result.passed, result.error).toBe(true);
+      expect(result.leak).toBe(0);
+    });
+
+    it('no raw using in bundle', async () => {
+      const code = await readFile(browserOutfile, 'utf-8');
+      expect(code).not.toMatch(/\busing\s+\w+\s*=/);
+    });
+  });
+});

--- a/tests/tree-shaking/fixtures/dispose-using-browser.ts
+++ b/tests/tree-shaking/fixtures/dispose-using-browser.ts
@@ -1,0 +1,123 @@
+/**
+ * Browser fixture: Symbol.dispose protocol through transpiled `using`
+ *
+ * Unlike dispose-using.ts (which self-executes and prints PASS), this fixture
+ * exports a run() function that returns structured results. This allows browser
+ * tests to dynamically import the bundled output, call run(), and assert against
+ * the returned object.
+ *
+ * When bundled with a downlevel target (e.g. ES2020), the `using` keyword is
+ * transpiled to a helper that looks up [Symbol.dispose] or
+ * [Symbol.for("Symbol.dispose")]. On WebKit (Safari), our polyfill provides
+ * the key; on Chromium/Firefox, the native symbol is used directly.
+ *
+ * Memory assertions follow the wasm-leaks pattern: warmup first, then measure
+ * over N iterations so allocator overhead washes out and leak-per-iteration
+ * must be exactly zero.
+ */
+import { zeros, ones, arange, wasmFreeBytes } from 'numpy-ts';
+
+const SIZE = 10_000;
+const ITERS = 10;
+
+export interface DisposeTestResult {
+  passed: boolean;
+  leak: number;
+  error?: string;
+}
+
+export function run(): DisposeTestResult {
+  try {
+    // Warmup: absorb one-time WASM heap initialization costs for each op.
+    for (let i = 0; i < 3; i++) {
+      zeros([SIZE]).dispose();
+      ones([SIZE]).dispose();
+      arange(SIZE).dispose();
+    }
+
+    // Absorb fixed allocator fragmentation from interleaving different sizes
+    /* eslint-disable @typescript-eslint/no-unused-vars -- using vars exist for dispose side-effect */
+    {
+      using a = zeros([SIZE]);
+      using b = ones([SIZE]);
+      using c = arange(SIZE);
+    }
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+
+    // --- Single array ---
+    const beforeSingle = wasmFreeBytes();
+    for (let i = 0; i < ITERS; i++) {
+      using arr = zeros([SIZE]);
+      if (arr.size !== SIZE) {
+        return { passed: false, leak: 0, error: `single: unexpected size ${arr.size}` };
+      }
+      if (wasmFreeBytes() >= beforeSingle) {
+        return { passed: false, leak: 0, error: 'single: memory not allocated during using block' };
+      }
+    }
+    const singleLeak = beforeSingle - wasmFreeBytes();
+    if (singleLeak > 0) {
+      return {
+        passed: false,
+        leak: singleLeak,
+        error: `single: leaked ${singleLeak} bytes over ${ITERS} iters`,
+      };
+    }
+
+    // --- Multiple arrays ---
+    const beforeMulti = wasmFreeBytes();
+    for (let i = 0; i < ITERS; i++) {
+      using a = zeros([SIZE]);
+      using b = ones([SIZE]);
+      using c = arange(SIZE);
+      if (a.size !== SIZE || b.size !== SIZE || c.size !== SIZE) {
+        return { passed: false, leak: 0, error: 'multi: unexpected size' };
+      }
+    }
+    const multiLeak = beforeMulti - wasmFreeBytes();
+    if (multiLeak > 0) {
+      return {
+        passed: false,
+        leak: multiLeak,
+        error: `multi: leaked ${multiLeak} bytes over ${ITERS} iters`,
+      };
+    }
+
+    // --- Nested blocks ---
+    const beforeNested = wasmFreeBytes();
+    for (let i = 0; i < ITERS; i++) {
+      using outer = zeros([SIZE]);
+      const afterOuter = wasmFreeBytes();
+      {
+        using inner = ones([SIZE]); // eslint-disable-line @typescript-eslint/no-unused-vars -- dispose side-effect
+        if (wasmFreeBytes() >= afterOuter) {
+          return { passed: false, leak: 0, error: 'nested: inner did not allocate' };
+        }
+      }
+      // Inner should be freed, outer still alive
+      if (outer.size !== SIZE) {
+        return { passed: false, leak: 0, error: 'nested: outer corrupted after inner dispose' };
+      }
+    }
+    const nestedLeak = beforeNested - wasmFreeBytes();
+    if (nestedLeak > 0) {
+      return {
+        passed: false,
+        leak: nestedLeak,
+        error: `nested: leaked ${nestedLeak} bytes over ${ITERS} iters`,
+      };
+    }
+
+    // --- Transpiler key ---
+    const key = Symbol.dispose || Symbol.for('Symbol.dispose');
+    const arr = zeros([1]);
+    if (typeof (arr as any)[key] !== 'function') {
+      return { passed: false, leak: 0, error: 'transpiler key: dispose method not found' };
+    }
+    (arr as any)[key]();
+
+    return { passed: true, leak: 0 };
+  } catch (e) {
+    return { passed: false, leak: 0, error: String(e) };
+  }
+}

--- a/tests/tree-shaking/fixtures/dispose-using.ts
+++ b/tests/tree-shaking/fixtures/dispose-using.ts
@@ -1,0 +1,46 @@
+/**
+ * Tree-shaking test fixture: Symbol.dispose protocol through transpiled `using`
+ *
+ * When bundled with a downlevel target (e.g. ES2020), the `using` keyword is
+ * transpiled to a helper that looks up [Symbol.dispose] or
+ * [Symbol.for("Symbol.dispose")]. This fixture verifies that:
+ *   1. The polyfill side-effect survives bundling (not tree-shaken away)
+ *   2. The transpiled helper finds the dispose method
+ *   3. Execution completes without "not disposable" errors
+ *
+ * Exit code 0 = PASS, non-zero = FAIL.
+ */
+import { zeros } from 'numpy-ts/core';
+
+function testUsing() {
+  // Transpiled `using` — the bundler's downlevel helper must find [Symbol.dispose]
+  using arr = zeros([2, 3]);
+  if (arr.shape[0] !== 2 || arr.shape[1] !== 3) {
+    throw new Error('FAIL: unexpected shape');
+  }
+}
+
+function testLoop() {
+  // Transpiled `using` inside a loop — each iteration should dispose
+  for (let i = 0; i < 3; i++) {
+    using temp = zeros([4]);
+    if (temp.size !== 4) throw new Error('FAIL: unexpected size');
+  }
+}
+
+function testExplicitKey() {
+  // Verify the Symbol.for key matches (this is what transpilers use as fallback)
+  const key = Symbol.dispose || Symbol.for('Symbol.dispose');
+  const arr = zeros([1]);
+  if (typeof (arr as any)[key] !== 'function') {
+    throw new Error('FAIL: dispose method not found via transpiler key');
+  }
+  (arr as any)[key]();
+}
+
+testUsing();
+testLoop();
+testExplicitKey();
+
+console.log('PASS: dispose protocol works');
+export {};

--- a/tests/unit/complex-coverage.test.ts
+++ b/tests/unit/complex-coverage.test.ts
@@ -491,6 +491,7 @@ const COMPLEX_BEHAVIOR: Record<string, ComplexBehavior> = {
   fft: 'skip', // namespace object
   wasmConfig: 'skip', // WASM runtime configuration object
   configureWasm: 'skip', // WASM runtime configuration function
+  wasmFreeBytes: 'skip', // WASM memory introspection function
   hasFloat16: 'skip', // Runtime feature detection flag (not a function)
 
   // IO functions

--- a/tests/unit/dispose-protocol.test.ts
+++ b/tests/unit/dispose-protocol.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Symbol.dispose protocol tests
+ *
+ * Verifies that NDArrayCore and ArrayStorage always expose [Symbol.dispose],
+ * regardless of whether the runtime provides Symbol.dispose natively (Node 22+)
+ * or the library polyfills it via Symbol.for("Symbol.dispose") (older runtimes,
+ * Safari). The polyfill key matches what TypeScript, esbuild, Babel, and SWC
+ * emit in their downlevel `using` helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ArrayStorage } from '../../src/common/storage';
+import { NDArrayCore } from '../../src/common/ndarray-core';
+
+// After importing storage.ts, Symbol.dispose is guaranteed to be defined
+// (either natively or via the polyfill).
+describe('Symbol.dispose polyfill', () => {
+  it('Symbol.dispose is defined', () => {
+    expect(Symbol.dispose).toBeDefined();
+    expect(typeof Symbol.dispose).toBe('symbol');
+  });
+
+  it('on polyfilled runtimes, equals Symbol.for("Symbol.dispose")', () => {
+    // On runtimes without native Symbol.dispose, the polyfill sets it to
+    // Symbol.for("Symbol.dispose"). On native runtimes (Node 22+), it's a
+    // distinct built-in symbol and the polyfill is a no-op.
+    // Both paths are correct — transpilers use:
+    //   Symbol.dispose || Symbol.for("Symbol.dispose")
+    // which picks the native symbol when available.
+    const isNative = Symbol.dispose !== Symbol.for('Symbol.dispose');
+    if (!isNative) {
+      expect(Symbol.dispose).toBe(Symbol.for('Symbol.dispose'));
+    }
+  });
+});
+
+describe('ArrayStorage[Symbol.dispose]', () => {
+  it('is a function on the prototype', () => {
+    expect(typeof ArrayStorage.prototype[Symbol.dispose]).toBe('function');
+  });
+
+  it('is non-optional (always present on instances)', () => {
+    const s = new ArrayStorage(new Float64Array([1, 2, 3]), [3], 'float64');
+    expect(s[Symbol.dispose]).toBeInstanceOf(Function);
+  });
+
+  it('calls dispose() and releases resources', () => {
+    const s = new ArrayStorage(new Float64Array([1, 2, 3]), [3], 'float64');
+
+    // Should not throw regardless of whether the storage is WASM-backed
+    expect(() => s[Symbol.dispose]()).not.toThrow();
+  });
+
+  it('double [Symbol.dispose] is safe (mirrors dispose())', () => {
+    const s = new ArrayStorage(new Float64Array([1, 2, 3]), [3], 'float64');
+    s[Symbol.dispose]();
+    expect(() => s[Symbol.dispose]()).not.toThrow();
+  });
+});
+
+describe('NDArrayCore[Symbol.dispose]', () => {
+  function makeArray(): NDArrayCore {
+    const storage = new ArrayStorage(new Float64Array([1, 2, 3, 4]), [2, 2], 'float64');
+    return new NDArrayCore(storage);
+  }
+
+  it('is a function on the prototype', () => {
+    expect(typeof NDArrayCore.prototype[Symbol.dispose]).toBe('function');
+  });
+
+  it('is non-optional (always present on instances)', () => {
+    const arr = makeArray();
+    expect(arr[Symbol.dispose]).toBeInstanceOf(Function);
+  });
+
+  it('calls dispose() and frees the underlying storage', () => {
+    const arr = makeArray();
+    arr[Symbol.dispose]();
+    // After dispose, the storage's WASM region is released
+    expect(arr.storage.isWasmBacked).toBe(false);
+  });
+
+  it('double [Symbol.dispose] is safe', () => {
+    const arr = makeArray();
+    arr[Symbol.dispose]();
+    expect(() => arr[Symbol.dispose]()).not.toThrow();
+  });
+});
+
+describe('transpiler interop', () => {
+  // Transpilers emit: Symbol.dispose || Symbol.for("Symbol.dispose")
+  // On native runtimes, Symbol.dispose is used directly.
+  // On polyfilled runtimes, Symbol.for("Symbol.dispose") is used.
+  const transpilerKey = Symbol.dispose || Symbol.for('Symbol.dispose');
+
+  it('NDArrayCore is discoverable via transpiler key', () => {
+    const arr = new NDArrayCore(new ArrayStorage(new Float64Array([1]), [1], 'float64'));
+
+    const method = (arr as any)[transpilerKey];
+    expect(typeof method).toBe('function');
+
+    method.call(arr);
+    expect(arr.storage.isWasmBacked).toBe(false);
+  });
+
+  it('ArrayStorage is discoverable via transpiler key', () => {
+    const s = new ArrayStorage(new Float64Array([1, 2]), [2], 'float64');
+
+    const method = (s as any)[transpilerKey];
+    expect(typeof method).toBe('function');
+
+    method.call(s);
+    expect(s.isWasmBacked).toBe(false);
+  });
+});

--- a/tests/unit/dispose-wasm-lifecycle.test.ts
+++ b/tests/unit/dispose-wasm-lifecycle.test.ts
@@ -1,0 +1,94 @@
+/**
+ * WASM lifecycle tests for dispose via `using`
+ *
+ * Validates that `using` properly frees WASM memory by checking
+ * wasmFreeBytes() before and after scoped array usage. Follows the same
+ * warmup + iteration pattern as the wasm-leaks suite so allocator overhead
+ * washes out and leak-per-iteration must be exactly zero.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { zeros, ones, arange, wasmFreeBytes } from '../../src/core/index';
+
+const ITERS = 10;
+const SIZE = 10_000;
+
+describe('using + wasmFreeBytes lifecycle', () => {
+  beforeAll(() => {
+    // Warmup: absorb one-time WASM heap initialization costs for each op.
+    for (let i = 0; i < 3; i++) {
+      zeros([SIZE]).dispose();
+      ones([SIZE]).dispose();
+      arange(SIZE).dispose();
+    }
+  });
+
+  it('single array: frees WASM memory each iteration', () => {
+    const before = wasmFreeBytes();
+
+    for (let i = 0; i < ITERS; i++) {
+      using arr = zeros([SIZE]);
+      expect(arr.size).toBe(SIZE);
+      expect(wasmFreeBytes()).toBeLessThan(before);
+    }
+
+    const leak = before - wasmFreeBytes();
+    expect(leak / ITERS, `leaks ${leak} bytes over ${ITERS} iters`).toBe(0);
+  });
+
+  it('multiple arrays: all freed each iteration', () => {
+    // Run once to absorb any fixed fragmentation from interleaving 3 alloc sizes
+    /* eslint-disable @typescript-eslint/no-unused-vars -- using vars exist for dispose side-effect */
+    {
+      using a = zeros([SIZE]);
+      using b = ones([SIZE]);
+      using c = arange(SIZE);
+    }
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+
+    const before = wasmFreeBytes();
+
+    for (let i = 0; i < ITERS; i++) {
+      using a = zeros([SIZE]);
+      using b = ones([SIZE]);
+      using c = arange(SIZE);
+      expect(a.size).toBe(SIZE);
+      expect(b.size).toBe(SIZE);
+      expect(c.size).toBe(SIZE);
+      expect(wasmFreeBytes()).toBeLessThan(before);
+    }
+
+    const leak = before - wasmFreeBytes();
+    expect(leak / ITERS, `leaks ${leak} bytes over ${ITERS} iters`).toBe(0);
+  });
+
+  it('nested blocks: inner disposes before outer', () => {
+    // Absorb fixed fragmentation from interleaving 2 alloc sizes
+    /* eslint-disable @typescript-eslint/no-unused-vars -- using vars exist for dispose side-effect */
+    {
+      using a = zeros([SIZE]);
+      using b = ones([SIZE]);
+    }
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+
+    const before = wasmFreeBytes();
+
+    for (let i = 0; i < ITERS; i++) {
+      using outer = zeros([SIZE]);
+      const afterOuter = wasmFreeBytes();
+
+      {
+        using inner = ones([SIZE]);
+        expect(wasmFreeBytes()).toBeLessThan(afterOuter);
+        expect(inner.size).toBe(SIZE);
+      }
+
+      // Inner freed, outer still alive
+      expect(wasmFreeBytes()).toBeLessThan(before);
+      expect(outer.size).toBe(SIZE);
+    }
+
+    const leak = before - wasmFreeBytes();
+    expect(leak / ITERS, `leaks ${leak} bytes over ${ITERS} iters`).toBe(0);
+  });
+});

--- a/tests/validation/exports.numpy.test.ts
+++ b/tests/validation/exports.numpy.test.ts
@@ -335,6 +335,7 @@ describe('NumPy API Comparison', () => {
         // WASM runtime configuration
         'wasmConfig',
         'configureWasm',
+        'wasmFreeBytes',
         // Runtime feature detection
         'hasFloat16',
         // Deprecated in NumPy 1.24+, removed in NumPy 2.0 (use isin instead)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -102,7 +102,9 @@ export default defineConfig({
         test: {
           name: 'browser-unit',
           include: ['tests/unit/**'],
-          exclude: ['**/node_modules/**', '**/__screenshots__/**'],
+          // Exclude dispose-wasm-lifecycle — it uses `using` syntax which WebKit can't parse.
+          // That file is covered by browser-dispose-vanilla (Chromium+Firefox only).
+          exclude: ['**/node_modules/**', '**/__screenshots__/**', '**/dispose-wasm-lifecycle*'],
           setupFiles: ['tests/setup-version.ts'],
           browser: {
             enabled: true,
@@ -158,6 +160,47 @@ export default defineConfig({
           testTimeout: 300000, // 5 minutes - bundling can take time
           sequence: { groupOrder: 2 },
           setupFiles: ['tests/tree-shaking/setup.ts'],
+        },
+      }),
+      // Browser dispose tests — bundled path (esbuild/rollup/webpack × all engines)
+      // Runs at groupOrder 3 so the tree-shaking project (groupOrder 2) has
+      // already built the browser bundles in .output/dispose/browser/.
+      // The test file contains NO `using` syntax — safe for WebKit.
+      defineProject({
+        test: {
+          name: 'browser-dispose',
+          include: ['tests/bundles/browser-dispose-bundled.test.ts'],
+          testTimeout: 60000,
+          sequence: { groupOrder: 3 },
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright({ launchOptions: { headless: true } }),
+            instances: [
+              { browser: 'chromium' },
+              { browser: 'firefox' },
+              { browser: 'webkit' },
+            ],
+          },
+        },
+      }),
+      // Browser dispose tests — vanilla path (native `using`, no transpiler)
+      // Chromium and Firefox only — WebKit cannot parse `using` syntax.
+      defineProject({
+        test: {
+          name: 'browser-dispose-vanilla',
+          include: ['tests/bundles/browser-dispose.test.ts'],
+          testTimeout: 60000,
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright({ launchOptions: { headless: true } }),
+            instances: [
+              { browser: 'chromium' },
+              { browser: 'firefox' },
+              // NO webkit — cannot parse `using` syntax
+            ],
+          },
         },
       }),
     ],


### PR DESCRIPTION
Title says it all. Built-in polyfill + validation tests across all browsers (including the main offender... Safari).