### PR TITLE
Nested args & missing args for various functions

### DIFF
--- a/scripts/generate-full.ts
+++ b/scripts/generate-full.ts
@@ -373,7 +373,7 @@ import { NDArray } from './ndarray';
 import { NDArrayCore } from '../common/ndarray-core';
 import { ArrayStorage } from '../common/storage';
 import { Complex } from '../common/complex';
-import type { DType, TypedArray } from '../core/types';
+import type { ArrayLike, DType, TypedArray } from '../core/types';
 import type { NestedNDArrays } from '../core/shape';
 import {
   DEFAULT_DTYPE,

--- a/scripts/generate-full.ts
+++ b/scripts/generate-full.ts
@@ -374,6 +374,7 @@ import { NDArrayCore } from '../common/ndarray-core';
 import { ArrayStorage } from '../common/storage';
 import { Complex } from '../common/complex';
 import type { DType, TypedArray } from '../core/types';
+import type { NestedNDArrays } from '../core/shape';
 import {
   DEFAULT_DTYPE,
   getTypedArrayConstructor,

--- a/scripts/generate-full.ts
+++ b/scripts/generate-full.ts
@@ -153,13 +153,14 @@ const CUSTOM_WRAPPERS: Record<string, { returnType: string; body: string }> = {
   };
   return up(core.apply_over_axes(wrappedFunc, a, axes));`,
   },
-  // apply_along_axis: callback receives NDArrayCore from core, but user expects NDArray
+  // apply_along_axis: callback receives NDArrayCore from core, but user expects NDArray.
+  // Forwards extra args (NumPy: apply_along_axis(func1d, axis, arr, *args)).
   apply_along_axis: {
     returnType: 'NDArray',
-    body: `const wrappedFunc1d = (arr: NDArrayCore): NDArrayCore | number => {
-    return func1d(up(arr));
+    body: `const wrappedFunc1d = (arr: NDArrayCore, ...passed: unknown[]): NDArrayCore | number => {
+    return func1d(up(arr), ...passed);
   };
-  return up(core.apply_along_axis(wrappedFunc1d, axis, arr));`,
+  return up(core.apply_along_axis(wrappedFunc1d, axis, arr, ...args));`,
   },
   // average can return either a single value or a tuple [avg, sum_of_weights]
   // when returned=true. Map the inner NDArrayCore values to NDArray.

--- a/scripts/generate-full.ts
+++ b/scripts/generate-full.ts
@@ -375,6 +375,7 @@ import { ArrayStorage } from '../common/storage';
 import { Complex } from '../common/complex';
 import type { ArrayLike, DType, TypedArray } from '../core/types';
 import type { NestedNDArrays } from '../core/shape';
+import type { PadValueArg, PadWidthArg } from '../core/shape-extra';
 import {
   DEFAULT_DTYPE,
   getTypedArrayConstructor,

--- a/scripts/generate-full.ts
+++ b/scripts/generate-full.ts
@@ -161,6 +161,19 @@ const CUSTOM_WRAPPERS: Record<string, { returnType: string; body: string }> = {
   };
   return up(core.apply_along_axis(wrappedFunc1d, axis, arr));`,
   },
+  // average can return either a single value or a tuple [avg, sum_of_weights]
+  // when returned=true. Map the inner NDArrayCore values to NDArray.
+  average: {
+    returnType: 'NDArray | number | Complex | [NDArray | number | Complex, NDArray | number]',
+    body: `const r = core.average(a, axis, weights, keepdims, returned);
+  if (Array.isArray(r)) {
+    const [avg, sw] = r;
+    const upAvg = avg instanceof NDArrayCore ? up(avg) : avg;
+    const upSw = sw instanceof NDArrayCore ? up(sw) : sw;
+    return [upAvg, upSw];
+  }
+  return r instanceof NDArrayCore ? up(r) : r;`,
+  },
 };
 
 // Functions returning arrays (should be wrapped)
@@ -376,6 +389,7 @@ import { Complex } from '../common/complex';
 import type { ArrayLike, DType, TypedArray } from '../core/types';
 import type { NestedNDArrays } from '../core/shape';
 import type { PadValueArg, PadWidthArg } from '../core/shape-extra';
+import type { ReductionOpts } from '../core/reduction';
 import {
   DEFAULT_DTYPE,
   getTypedArrayConstructor,

--- a/scripts/ndarray-methods.ts
+++ b/scripts/ndarray-methods.ts
@@ -528,49 +528,57 @@ tofile(_file: string, _sep: string = '', _format: string = ''): void {
 // ============================================================
 
 export const MESHGRID_FUNCTION = `\
-export function meshgrid(...args: (NDArray | { indexing?: 'xy' | 'ij' })[]): NDArray[] {
+export interface MeshgridOptions {
+  /** 'xy' (default, NumPy-compatible) or 'ij' Cartesian/matrix indexing */
+  indexing?: 'xy' | 'ij';
+  /** If true, return open (non-broadcasted) grids — outputs have shape 1 except along their own axis */
+  sparse?: boolean;
+  /** If true (default), each output owns its data. If false, outputs are views (broadcast). */
+  copy?: boolean;
+}
+
+export function meshgrid(...args: (NDArray | MeshgridOptions)[]): NDArray[] {
   let arrays: NDArray[] = [];
   let indexing: 'xy' | 'ij' = 'xy';
+  let sparse = false;
+  let copy = true;
 
   for (const arg of args) {
     if (arg instanceof NDArray) {
       arrays.push(arg);
-    } else if (typeof arg === 'object' && 'indexing' in arg) {
-      indexing = arg.indexing || 'xy';
+    } else if (arg && typeof arg === 'object') {
+      if ('indexing' in arg && arg.indexing) indexing = arg.indexing;
+      if ('sparse' in arg && arg.sparse !== undefined) sparse = arg.sparse;
+      if ('copy' in arg && arg.copy !== undefined) copy = arg.copy;
     }
   }
 
-  if (arrays.length === 0) {
-    return [];
-  }
-
+  if (arrays.length === 0) return [];
   if (arrays.length === 1) {
-    return [arrays[0]!.copy()];
+    const a = arrays[0]!;
+    return [copy ? a.copy() : a];
   }
-
-  const sizes = arrays.map((a) => a.size);
 
   if (indexing === 'xy' && arrays.length >= 2) {
     arrays = [arrays[1]!, arrays[0]!, ...arrays.slice(2)];
-    [sizes[0], sizes[1]] = [sizes[1]!, sizes[0]!];
   }
 
-  const outputShape = sizes;
-  const ndim = outputShape.length;
+  const sizes = arrays.map((a) => a.size);
+  const ndim = sizes.length;
 
   const results: NDArray[] = [];
-
   for (let i = 0; i < arrays.length; i++) {
-    const inputArr = arrays[i]!;
-    const inputSize = inputArr.size;
-
     const broadcastShape: number[] = new Array(ndim).fill(1);
-    broadcastShape[i] = inputSize;
+    broadcastShape[i] = sizes[i]!;
 
-    const reshaped = inputArr.reshape(...broadcastShape);
-    const resultStorage = core.broadcast_to(reshaped, outputShape);
-    const result = NDArray.fromStorage(resultStorage.storage.copy());
-    results.push(result);
+    const reshaped = arrays[i]!.reshape(...broadcastShape);
+    if (sparse) {
+      results.push(copy ? reshaped.copy() : reshaped);
+      continue;
+    }
+    const broadcasted = core.broadcast_to(reshaped, sizes);
+    const out = NDArray.fromStorage(copy ? broadcasted.storage.copy() : broadcasted.storage);
+    results.push(out);
   }
 
   if (indexing === 'xy' && results.length >= 2) {

--- a/scripts/ndarray-methods.ts
+++ b/scripts/ndarray-methods.ts
@@ -474,7 +474,10 @@ isclose(other: NDArray | number, rtol: number = 1e-5, atol: number = 1e-8): NDAr
 
 const AVERAGE_METHOD = `\
 average(weights?: NDArray, axis?: number): NDArray | number | Complex {
-    const r = core.average(this, axis, weights);
+    const r = core.average(this, axis, weights, false, false) as
+      | NDArrayCore
+      | number
+      | Complex;
     return r instanceof NDArrayCore ? up(r) : r;
   }`;
 

--- a/src/common/ops/advanced.ts
+++ b/src/common/ops/advanced.ts
@@ -789,7 +789,7 @@ export function compress(
 export function select(
   condlist: ArrayStorage[],
   choicelist: ArrayStorage[],
-  defaultValue: number | bigint = 0,
+  defaultValue: ArrayStorage | number | bigint = 0,
 ): ArrayStorage {
   if (condlist.length !== choicelist.length) {
     throw new Error('condlist and choicelist must have same length');
@@ -799,11 +799,14 @@ export function select(
     throw new Error('condlist and choicelist cannot be empty');
   }
 
-  // Compute broadcast shape from all conditions and choices
+  // Compute broadcast shape across conds, choices, and (if array) the default
   const allShapes = [
     ...condlist.map((c) => Array.from(c.shape)),
     ...choicelist.map((c) => Array.from(c.shape)),
   ];
+  if (defaultValue instanceof ArrayStorage) {
+    allShapes.push(Array.from(defaultValue.shape));
+  }
   const outputShape = computeBroadcastShape(allShapes);
   if (outputShape === null) {
     throw new Error('condlist and choicelist arrays could not be broadcast together');
@@ -812,30 +815,43 @@ export function select(
   const dtype = choicelist[0]!.dtype;
   const outputSize = outputShape.reduce((a, b) => a * b, 1);
 
-  // Initialize with default value
-  const defaultVal: number | bigint = isBigIntDType(dtype)
-    ? typeof defaultValue === 'bigint'
-      ? defaultValue
-      : BigInt(defaultValue)
-    : typeof defaultValue === 'bigint'
-      ? Number(defaultValue)
-      : defaultValue;
-
   const selectResult = ArrayStorage.empty(outputShape, dtype);
   const outputData = selectResult.data;
-  for (let i = 0; i < outputSize; i++) {
-    if (isBigIntDType(dtype)) {
-      (outputData as BigInt64Array | BigUint64Array)[i] = defaultVal as bigint;
-    } else {
-      (outputData as Exclude<TypedArray, BigInt64Array | BigUint64Array>)[i] = defaultVal as number;
+
+  // Initialize with default — scalar or broadcasted array
+  if (defaultValue instanceof ArrayStorage) {
+    const defaultBroadcast = broadcastTo(defaultValue, outputShape);
+    for (let i = 0; i < outputSize; i++) {
+      const v = defaultBroadcast.iget(i);
+      if (isBigIntDType(dtype)) {
+        (outputData as BigInt64Array | BigUint64Array)[i] = v as bigint;
+      } else {
+        (outputData as Exclude<TypedArray, BigInt64Array | BigUint64Array>)[i] = v as number;
+      }
+    }
+  } else {
+    const defaultVal: number | bigint = isBigIntDType(dtype)
+      ? typeof defaultValue === 'bigint'
+        ? defaultValue
+        : BigInt(defaultValue)
+      : typeof defaultValue === 'bigint'
+        ? Number(defaultValue)
+        : defaultValue;
+    for (let i = 0; i < outputSize; i++) {
+      if (isBigIntDType(dtype)) {
+        (outputData as BigInt64Array | BigUint64Array)[i] = defaultVal as bigint;
+      } else {
+        (outputData as Exclude<TypedArray, BigInt64Array | BigUint64Array>)[i] =
+          defaultVal as number;
+      }
     }
   }
 
-  // Broadcast all arrays
+  // Broadcast conds/choices
   const broadcastedConds = condlist.map((c) => broadcastTo(c, outputShape));
   const broadcastedChoices = choicelist.map((c) => broadcastTo(c, outputShape));
 
-  // Process conditions in order (first match wins)
+  // First-match-wins
   for (let i = 0; i < outputSize; i++) {
     for (let j = 0; j < condlist.length; j++) {
       if (broadcastedConds[j]!.iget(i)) {

--- a/src/common/ops/arithmetic.ts
+++ b/src/common/ops/arithmetic.ts
@@ -2959,6 +2959,7 @@ export function interp(
   fp: ArrayStorage,
   left?: number,
   right?: number,
+  period?: number,
 ): ArrayStorage {
   throwIfComplex(x.dtype, 'interp', 'interp is not supported for complex numbers.');
   throwIfComplex(xp.dtype, 'interp', 'interp is not supported for complex numbers.');
@@ -2972,6 +2973,51 @@ export function interp(
   const xpData = xp.data;
   const fpData = fp.data;
   const xpSize = xp.size;
+
+  // Periodic interpolation: x and xp are normalized into [0, period); xp is
+  // sorted; xp/fp are wrap-extended so any normalized x lies within range.
+  // left/right are ignored when period is provided.
+  if (period !== undefined) {
+    if (period === 0) {
+      throw new Error('period must be a non-zero value');
+    }
+    const P = Math.abs(period);
+    const pyMod = (a: number, b: number): number => ((a % b) + b) % b;
+
+    const xpNorm: number[] = new Array(xpSize);
+    const fpNorm: number[] = new Array(xpSize);
+    for (let i = 0; i < xpSize; i++) {
+      xpNorm[i] = pyMod(Number(xpData[i]!), P);
+      fpNorm[i] = Number(fpData[i]!);
+    }
+    const order = xpNorm.map((_, i) => i).sort((a, b) => xpNorm[a]! - xpNorm[b]!);
+    const sortedXp = order.map((i) => xpNorm[i]!);
+    const sortedFp = order.map((i) => fpNorm[i]!);
+    // Wrap-extend by one element on each side.
+    const extXp = [sortedXp[sortedXp.length - 1]! - P, ...sortedXp, sortedXp[0]! + P];
+    const extFp = [sortedFp[sortedFp.length - 1]!, ...sortedFp, sortedFp[0]!];
+    const extLen = extXp.length;
+
+    for (let i = 0; i < size; i++) {
+      const xi = pyMod(Number(xData[i]!), P);
+
+      // Binary search in extended xp.
+      let lo = 0;
+      let hi = extLen - 1;
+      while (hi - lo > 1) {
+        const mid = (lo + hi) >> 1;
+        if (extXp[mid]! <= xi) lo = mid;
+        else hi = mid;
+      }
+      const x0 = extXp[lo]!;
+      const x1 = extXp[hi]!;
+      const y0 = extFp[lo]!;
+      const y1 = extFp[hi]!;
+      resultData[i] = x0 === x1 ? y0 : y0 + ((xi - x0) / (x1 - x0)) * (y1 - y0);
+    }
+
+    return result;
+  }
 
   // Default left/right values
   const leftVal = left !== undefined ? left : Number(fpData[0]!);

--- a/src/common/ops/gradient.ts
+++ b/src/common/ops/gradient.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Complex } from '../complex';
-import { isBigIntDType, isComplexDType, promoteDTypes } from '../dtype';
+import { isBigIntDType, isComplexDType, promoteDTypes, type TypedArray } from '../dtype';
 import { ArrayStorage } from '../storage';
 import { wasmDiff } from '../wasm/diff';
 import { wasmGradient1D } from '../wasm/gradient';
@@ -250,9 +250,12 @@ export function ediff1d(
  * @param axis - Axis or axes along which to compute gradient (default: all axes)
  * @returns Array of gradients (one per axis) or single gradient if one axis
  */
+/** Per-axis spacing: either a scalar (uniform) or a 1-D coordinate array along that axis. */
+export type GradientSpacing = number | number[];
+
 export function gradient(
   f: ArrayStorage,
-  varargs: number | number[] = 1,
+  varargs: number | GradientSpacing[] = 1,
   axis: number | number[] | null = null,
 ): ArrayStorage | ArrayStorage[] {
   if (f.dtype === 'bool') {
@@ -283,8 +286,10 @@ export function gradient(
     });
   }
 
-  // Determine spacing for each axis
-  let spacings: number[];
+  // Per-axis spacing. A single scalar broadcasts across all axes; otherwise the
+  // length must match the number of axes. Each entry may be a scalar (uniform)
+  // or a 1-D coordinate array of length axisSize (non-uniform).
+  let spacings: GradientSpacing[];
   if (typeof varargs === 'number') {
     spacings = axes.map(() => varargs);
   } else {
@@ -294,28 +299,123 @@ export function gradient(
     spacings = varargs;
   }
 
-  // WASM fast path for 1D gradient with uniform spacing
+  // WASM fast path: 1-D, uniform scalar spacing, non-complex.
   if (
     axes.length === 1 &&
     f.shape.length === 1 &&
     !isComplexDType(f.dtype) &&
     typeof varargs === 'number'
   ) {
-    const wasm = wasmGradient1D(f, spacings[0]!);
+    const wasm = wasmGradient1D(f, varargs);
     if (wasm) return wasm;
   }
 
-  // Compute gradient for each axis
   const results: ArrayStorage[] = [];
   for (let i = 0; i < axes.length; i++) {
-    results.push(gradientAlongAxis(f, axes[i]!, spacings[i]!));
+    const sp = spacings[i]!;
+    const ax = axes[i]!;
+    if (typeof sp === 'number') {
+      results.push(gradientAlongAxis(f, ax, sp));
+    } else {
+      if (sp.length !== shape[ax]!) {
+        throw new Error(
+          `coordinate array for axis ${ax} has length ${sp.length}, expected ${shape[ax]!}`,
+        );
+      }
+      results.push(gradientAlongAxisCoords(f, ax, sp));
+    }
   }
 
-  // Return single result if single axis
   if (results.length === 1) {
     return results[0]!;
   }
   return results;
+}
+
+/**
+ * Non-uniform second-order central difference using explicit coordinates.
+ * For interior point i with hd = x[i] - x[i-1] and hs = x[i+1] - x[i]:
+ *
+ *   grad[i] = (-hs² · f[i-1] + (hs² - hd²) · f[i] + hd² · f[i+1]) / (hd · hs · (hd + hs))
+ *
+ * Boundaries fall back to first-order forward/backward differences.
+ */
+function gradientAlongAxisCoords(
+  f: ArrayStorage,
+  axis: number,
+  coords: number[],
+): ArrayStorage {
+  const shape = Array.from(f.shape);
+  const ndim = shape.length;
+  const axisSize = shape[axis]!;
+
+  if (axisSize < 2) {
+    throw new Error(`Shape of array along axis ${axis} must be at least 2, but got ${axisSize}`);
+  }
+
+  const dtype = f.dtype;
+  if (isComplexDType(dtype)) {
+    throw new Error('gradient with coordinate arrays is not yet supported for complex dtypes');
+  }
+
+  const resultDtype = isBigIntDType(dtype)
+    ? 'float64'
+    : dtype === 'float16' || dtype === 'float32'
+      ? dtype
+      : 'float64';
+
+  const result = ArrayStorage.zeros(shape, resultDtype);
+  const resultData = result.data as Exclude<TypedArray, BigInt64Array | BigUint64Array>;
+  const strides = f.strides;
+  const off = f.offset;
+  const totalSize = f.size;
+
+  for (let flatIdx = 0; flatIdx < totalSize; flatIdx++) {
+    let remaining = flatIdx;
+    const indices: number[] = new Array(ndim);
+    for (let d = ndim - 1; d >= 0; d--) {
+      indices[d] = remaining % shape[d]!;
+      remaining = Math.floor(remaining / shape[d]!);
+    }
+
+    let currentBufIdx = off;
+    for (let d = 0; d < ndim; d++) {
+      currentBufIdx += indices[d]! * strides[d]!;
+    }
+
+    const i = indices[axis]!;
+    let value: number;
+
+    const readAt = (axisIdx: number): number => {
+      let bufIdx = off;
+      for (let d = 0; d < ndim; d++) {
+        bufIdx += (d === axis ? axisIdx : indices[d]!) * strides[d]!;
+      }
+      return Number(f.data[bufIdx]!);
+    };
+
+    if (i === 0) {
+      const f0 = Number(f.data[currentBufIdx]!);
+      const f1 = readAt(1);
+      value = (f1 - f0) / (coords[1]! - coords[0]!);
+    } else if (i === axisSize - 1) {
+      const fN = Number(f.data[currentBufIdx]!);
+      const fNm1 = readAt(axisSize - 2);
+      value = (fN - fNm1) / (coords[axisSize - 1]! - coords[axisSize - 2]!);
+    } else {
+      const hd = coords[i]! - coords[i - 1]!;
+      const hs = coords[i + 1]! - coords[i]!;
+      const fm = readAt(i - 1);
+      const fc = Number(f.data[currentBufIdx]!);
+      const fp = readAt(i + 1);
+      value =
+        (-(hs * hs) * fm + (hs * hs - hd * hd) * fc + hd * hd * fp) / (hd * hs * (hd + hs));
+    }
+
+    resultData[flatIdx] = value;
+  }
+
+  return result;
 }
 
 /**

--- a/src/common/ops/gradient.ts
+++ b/src/common/ops/gradient.ts
@@ -340,11 +340,7 @@ export function gradient(
  *
  * Boundaries fall back to first-order forward/backward differences.
  */
-function gradientAlongAxisCoords(
-  f: ArrayStorage,
-  axis: number,
-  coords: number[],
-): ArrayStorage {
+function gradientAlongAxisCoords(f: ArrayStorage, axis: number, coords: number[]): ArrayStorage {
   const shape = Array.from(f.shape);
   const ndim = shape.length;
   const axisSize = shape[axis]!;
@@ -408,8 +404,7 @@ function gradientAlongAxisCoords(
       const fm = readAt(i - 1);
       const fc = Number(f.data[currentBufIdx]!);
       const fp = readAt(i + 1);
-      value =
-        (-(hs * hs) * fm + (hs * hs - hd * hd) * fc + hd * hd * fp) / (hd * hs * (hd + hs));
+      value = (-(hs * hs) * fm + (hs * hs - hd * hd) * fc + hd * hd * fp) / (hd * hs * (hd + hs));
     }
 
     resultData[flatIdx] = value;

--- a/src/common/ops/shape.ts
+++ b/src/common/ops/shape.ts
@@ -1800,18 +1800,37 @@ export function unstack(storage: ArrayStorage, axis: number = 0): ArrayStorage[]
   return results;
 }
 
-/**
- * Assemble an nd-array from nested lists of blocks
- * For a simple list [a, b] of nD arrays, concatenates along the last axis (like np.block)
- */
-export function block(storages: ArrayStorage[], _depth: number = 1): ArrayStorage {
-  if (storages.length === 0) {
+export type NestedBlock = ArrayStorage | NestedBlock[];
+
+function blockListDepth(x: NestedBlock): number {
+  if (!Array.isArray(x)) return 0;
+  let max = 0;
+  for (const child of x) {
+    const d = blockListDepth(child);
+    if (d > max) max = d;
+  }
+  return 1 + max;
+}
+
+function blockRecursive(x: NestedBlock, depthFromTop: number): ArrayStorage {
+  if (!Array.isArray(x)) return x;
+  if (x.length === 0) {
     throw new Error('need at least one array to block');
   }
-  if (storages.length === 1) {
-    return storages[0]!.copy();
+  const parts = x.map((child) => blockRecursive(child, depthFromTop - 1));
+  if (parts.length === 1) return parts[0]!.copy();
+  return concatenate(parts, -depthFromTop);
+}
+
+/**
+ * Assemble an nd-array from nested lists of blocks (np.block semantics).
+ * Each nesting level concatenates along a different axis: the innermost list
+ * along axis -1, the next along axis -2, and so on.
+ */
+export function block(arrays: NestedBlock): ArrayStorage {
+  const totalDepth = blockListDepth(arrays);
+  if (totalDepth === 0) {
+    return (arrays as ArrayStorage).copy();
   }
-  // np.block([a, b]) for nD arrays concatenates along the last axis (-1)
-  // This matches NumPy's behavior where a flat list of arrays is joined horizontally
-  return concatenate(storages, -1);
+  return blockRecursive(arrays, totalDepth);
 }

--- a/src/core/advanced.ts
+++ b/src/core/advanced.ts
@@ -166,13 +166,17 @@ export function bindex(a: NDArrayCore, mask: NDArrayCore, axis?: number): NDArra
 }
 
 export function select(
-  condlist: NDArrayCore[],
-  choicelist: NDArrayCore[],
-  defaultVal: number = 0,
+  condlist: ArrayLike[],
+  choicelist: ArrayLike[],
+  defaultVal: ArrayLike = 0,
 ): NDArrayCore {
-  const condStorages = condlist.map(toStorage);
-  const choiceStorages = choicelist.map(toStorage);
-  return fromStorage(advancedOps.select(condStorages, choiceStorages, defaultVal));
+  const condStorages = condlist.map((c) => toStorage(asarray(c)));
+  const choiceStorages = choicelist.map((c) => toStorage(asarray(c)));
+  const defaultArg =
+    typeof defaultVal === 'number' || typeof defaultVal === 'bigint'
+      ? defaultVal
+      : toStorage(asarray(defaultVal));
+  return fromStorage(advancedOps.select(condStorages, choiceStorages, defaultArg));
 }
 
 export function place(a: NDArrayCore, mask: NDArrayCore, vals: NDArrayCore): void {

--- a/src/core/advanced.ts
+++ b/src/core/advanced.ts
@@ -333,12 +333,13 @@ export function array_equiv(a: NDArrayCore, b: NDArrayCore): boolean {
 // ============================================================
 
 export function apply_along_axis(
-  func1d: (arr: NDArrayCore) => NDArrayCore | number,
+  func1d: (arr: NDArrayCore, ...args: unknown[]) => NDArrayCore | number,
   axis: number,
   arr: NDArrayCore,
+  ...args: unknown[]
 ): NDArrayCore {
   const wrappedFunc = (storage: ArrayStorage): ArrayStorage | number => {
-    const result = func1d(fromStorage(storage));
+    const result = func1d(fromStorage(storage), ...args);
     return typeof result === 'number' ? result : toStorage(result);
   };
   return fromStorage(advancedOps.apply_along_axis(toStorage(arr), axis, wrappedFunc));

--- a/src/core/advanced.ts
+++ b/src/core/advanced.ts
@@ -10,8 +10,10 @@ import { NDArrayCore } from '../common/ndarray-core';
 import * as advancedOps from '../common/ops/advanced';
 import * as comparisonOps from '../common/ops/comparison';
 import type { ArrayStorage } from '../common/storage';
-import { array } from './creation';
+import * as shapeOps from '../common/ops/shape';
+import { array, asarray } from './creation';
 import { fromStorage, fromStorageView, toStorage } from './types';
+import type { ArrayLike } from './types';
 
 // ============================================================
 // Broadcasting
@@ -61,8 +63,47 @@ export function broadcast_shapes(...shapes: number[][]): number[] {
 // Indexing Operations
 // ============================================================
 
-export function take(a: NDArrayCore, indices: number[], axis?: number): NDArrayCore {
-  return fromStorage(advancedOps.take(toStorage(a), indices, axis));
+export function take(a: NDArrayCore, indices: ArrayLike, axis?: number): NDArrayCore {
+  // Fast path: a flat number[] of indices → no shape preservation needed,
+  // skip the asarray() wrap to avoid an extra WASM allocation per call.
+  if (Array.isArray(indices) && (indices.length === 0 || typeof indices[0] === 'number')) {
+    return fromStorage(advancedOps.take(toStorage(a), indices as number[], axis));
+  }
+
+  // Scalar index: NumPy reduces rank by one along the axis.
+  if (typeof indices === 'number' || typeof indices === 'bigint') {
+    const flatResult = advancedOps.take(toStorage(a), [Number(indices)], axis);
+    if (axis === undefined) {
+      // Drop the trailing length-1 dim → 0-D result
+      return fromStorage(shapeOps.reshape(flatResult, []));
+    }
+    const ndim = a.shape.length;
+    const k = axis < 0 ? ndim + axis : axis;
+    const outputShape = [...a.shape.slice(0, k), ...a.shape.slice(k + 1)];
+    return fromStorage(shapeOps.reshape(flatResult, outputShape));
+  }
+
+  // Multi-dim or NDArray indices: preserve indices' shape in the output.
+  const idxArr = asarray(indices);
+  const idxShape = Array.from(idxArr.shape);
+  const flatIndices: number[] = Array.from(
+    idxArr.data as { length: number; [n: number]: number | bigint },
+    (v) => Number(v),
+  );
+
+  const flatResult = advancedOps.take(toStorage(a), flatIndices, axis);
+
+  if (idxShape.length === 1) return fromStorage(flatResult);
+
+  let outputShape: number[];
+  if (axis === undefined) {
+    outputShape = idxShape;
+  } else {
+    const ndim = a.shape.length;
+    const k = axis < 0 ? ndim + axis : axis;
+    outputShape = [...a.shape.slice(0, k), ...idxShape, ...a.shape.slice(k + 1)];
+  }
+  return fromStorage(shapeOps.reshape(flatResult, outputShape));
 }
 
 export function put(a: NDArrayCore, indices: number[], values: NDArrayCore | number[]): void {

--- a/src/core/advanced.ts
+++ b/src/core/advanced.ts
@@ -9,11 +9,11 @@ import { type DType, isBigIntDType } from '../common/dtype';
 import { NDArrayCore } from '../common/ndarray-core';
 import * as advancedOps from '../common/ops/advanced';
 import * as comparisonOps from '../common/ops/comparison';
-import type { ArrayStorage } from '../common/storage';
 import * as shapeOps from '../common/ops/shape';
+import type { ArrayStorage } from '../common/storage';
 import { array, asarray } from './creation';
-import { fromStorage, fromStorageView, toStorage } from './types';
 import type { ArrayLike } from './types';
+import { fromStorage, fromStorageView, toStorage } from './types';
 
 // ============================================================
 // Broadcasting

--- a/src/core/arithmetic.ts
+++ b/src/core/arithmetic.ts
@@ -277,15 +277,19 @@ export function nan_to_num(
   return fromStorage(arithmeticOps.nan_to_num(toStorage(x), nan, posinf, neginf));
 }
 
-/** 1D linear interpolation */
+/** 1D linear interpolation. If `period` is given, x and xp are normalized into
+ *  `[0, period)` and the curve wraps at the boundary; `left`/`right` are ignored. */
 export function interp(
   x: NDArrayCore,
   xp: NDArrayCore,
   fp: NDArrayCore,
   left?: number,
   right?: number,
+  period?: number,
 ): NDArrayCore {
-  return fromStorage(arithmeticOps.interp(toStorage(x), toStorage(xp), toStorage(fp), left, right));
+  return fromStorage(
+    arithmeticOps.interp(toStorage(x), toStorage(xp), toStorage(fp), left, right, period),
+  );
 }
 
 /** Unwrap phase angles */

--- a/src/core/creation.ts
+++ b/src/core/creation.ts
@@ -1042,7 +1042,7 @@ export interface MeshgridOptions {
 }
 
 export function meshgrid(...args: (NDArrayCore | MeshgridOptions)[]): NDArrayCore[] {
-  let arrays: NDArrayCore[] = [];
+  const arrays: NDArrayCore[] = [];
   let indexing: 'xy' | 'ij' = 'xy';
   let sparse = false;
   let copy = true;

--- a/src/core/creation.ts
+++ b/src/core/creation.ts
@@ -17,8 +17,11 @@ import {
   type TypedArray,
 } from '../common/dtype';
 import { type DType, NDArrayCore } from '../common/ndarray-core';
+import * as advancedOps from '../common/ops/advanced';
+import * as shapeOps from '../common/ops/shape';
 import { ArrayStorage } from '../common/storage';
 import { wasmAllFinite } from '../common/wasm/all_finite';
+import { toStorage } from './types';
 
 // Re-export types
 export type { DType, TypedArray } from '../common/dtype';
@@ -1029,37 +1032,64 @@ export function fromfile(
   throw new Error('fromfile requires Node.js file system access');
 }
 
-export function meshgrid(...arrays: NDArrayCore[]): NDArrayCore[] {
-  if (arrays.length === 0) return [];
-  if (arrays.length === 1) return [arrays[0]!.copy()];
+export interface MeshgridOptions {
+  /** 'xy' (default, NumPy-compatible) or 'ij' Cartesian/matrix indexing */
+  indexing?: 'xy' | 'ij';
+  /** If true, return open (non-broadcasted) grids — outputs have shape 1 except along their own axis */
+  sparse?: boolean;
+  /** If true (default), each output owns its data. If false, returns views (broadcast). */
+  copy?: boolean;
+}
 
-  const shapes = arrays.map((a) => a.size);
-  const outputShape = [...shapes];
+export function meshgrid(...args: (NDArrayCore | MeshgridOptions)[]): NDArrayCore[] {
+  let arrays: NDArrayCore[] = [];
+  let indexing: 'xy' | 'ij' = 'xy';
+  let sparse = false;
+  let copy = true;
+
+  for (const arg of args) {
+    if (arg instanceof NDArrayCore) {
+      arrays.push(arg);
+    } else if (arg && typeof arg === 'object') {
+      if ('indexing' in arg && arg.indexing) indexing = arg.indexing;
+      if ('sparse' in arg && arg.sparse !== undefined) sparse = arg.sparse;
+      if ('copy' in arg && arg.copy !== undefined) copy = arg.copy;
+    }
+  }
+
+  if (arrays.length === 0) return [];
+  if (arrays.length === 1) {
+    const a = arrays[0]!;
+    return [copy ? a.copy() : a];
+  }
+
+  // 'xy' swaps the first two axes relative to 'ij'.
+  const swap = indexing === 'xy' && arrays.length >= 2;
+  const orderedArrays = swap ? [arrays[1]!, arrays[0]!, ...arrays.slice(2)] : [...arrays];
+
+  const sizes = orderedArrays.map((a) => a.size);
+  const ndim = sizes.length;
+  const fullShape = sizes;
 
   const results: NDArrayCore[] = [];
+  for (let i = 0; i < orderedArrays.length; i++) {
+    const inputArr = orderedArrays[i]!;
+    const broadcastShape: number[] = new Array(ndim).fill(1);
+    broadcastShape[i] = sizes[i]!;
 
-  for (let dim = 0; dim < arrays.length; dim++) {
-    const arr = arrays[dim]!;
-    const data = arr.data;
-    const result = zeros(outputShape, arr.dtype as DType);
-    const resultData = result.data;
-
-    // Calculate strides for output
-    const strides: number[] = [];
-    let strideVal = 1;
-    for (let i = outputShape.length - 1; i >= 0; i--) {
-      strides.unshift(strideVal);
-      strideVal *= outputShape[i]!;
+    const reshaped = shapeOps.reshape(toStorage(inputArr), broadcastShape);
+    if (sparse) {
+      const sp = NDArrayCore.fromStorage(copy ? reshaped.copy() : reshaped);
+      results.push(sp);
+      continue;
     }
+    const broadcasted = advancedOps.broadcast_to(reshaped, fullShape);
+    const out = NDArrayCore.fromStorage(copy ? broadcasted.copy() : broadcasted);
+    results.push(out);
+  }
 
-    const totalSize = outputShape.reduce((a, b) => a * b, 1);
-    for (let flatIdx = 0; flatIdx < totalSize; flatIdx++) {
-      // Get the index along this dimension
-      const idx = Math.floor(flatIdx / strides[dim]!) % shapes[dim]!;
-      (resultData as Float64Array)[flatIdx] = data[idx] as number;
-    }
-
-    results.push(result);
+  if (swap) {
+    [results[0], results[1]] = [results[1]!, results[0]!];
   }
 
   return results;

--- a/src/core/gradient.ts
+++ b/src/core/gradient.ts
@@ -6,7 +6,8 @@
  */
 
 import * as gradientOps from '../common/ops/gradient';
-import { fromStorage, fromStorageArray, type NDArrayCore, toStorage } from './types';
+import { NDArrayCore } from '../common/ndarray-core';
+import { fromStorage, fromStorageArray, toStorage } from './types';
 
 /** Calculate n-th discrete difference */
 export function diff(a: NDArrayCore, n?: number, axis?: number): NDArrayCore {
@@ -22,13 +23,28 @@ export function ediff1d(
   return fromStorage(gradientOps.ediff1d(toStorage(a), to_end ?? null, to_begin ?? null));
 }
 
+/** Per-axis spacing: scalar (uniform) or 1-D coordinate array (non-uniform). */
+export type GradientSpacingArg = number | number[] | NDArrayCore;
+
 /** Return gradient of N-dimensional array */
 export function gradient(
   f: NDArrayCore,
-  varargs?: number | number[],
+  varargs?: number | GradientSpacingArg[],
   axis?: number | number[] | null,
 ): NDArrayCore | NDArrayCore[] {
-  const result = gradientOps.gradient(toStorage(f), varargs, axis);
+  let opVarargs: number | gradientOps.GradientSpacing[] | undefined;
+  if (varargs === undefined || typeof varargs === 'number') {
+    opVarargs = varargs;
+  } else {
+    opVarargs = varargs.map((v) => {
+      if (typeof v === 'number') return v;
+      if (v instanceof NDArrayCore) {
+        return Array.from(toStorage(v).data as ArrayLike<number>, (x) => Number(x));
+      }
+      return v;
+    });
+  }
+  const result = gradientOps.gradient(toStorage(f), opVarargs, axis);
   if (Array.isArray(result)) {
     return fromStorageArray(result);
   }

--- a/src/core/gradient.ts
+++ b/src/core/gradient.ts
@@ -5,8 +5,8 @@
  * imported independently for optimal tree-shaking.
  */
 
-import * as gradientOps from '../common/ops/gradient';
 import { NDArrayCore } from '../common/ndarray-core';
+import * as gradientOps from '../common/ops/gradient';
 import * as shapeOps from '../common/ops/shape';
 import { asarray, full } from './creation';
 import { type ArrayLike, fromStorage, fromStorageArray, toStorage } from './types';
@@ -16,11 +16,7 @@ import { type ArrayLike, fromStorage, fromStorageArray, toStorage } from './type
  * with `a` for concatenation along `axis` (NumPy: scalar broadcasts to size 1
  * along axis with `a`'s shape on all other axes).
  */
-function expandDiffSide(
-  value: ArrayLike,
-  a: NDArrayCore,
-  axis: number,
-): NDArrayCore {
+function expandDiffSide(value: ArrayLike, a: NDArrayCore, axis: number): NDArrayCore {
   if (typeof value === 'number' || typeof value === 'bigint') {
     const targetShape = Array.from(a.shape);
     targetShape[axis] = 1;

--- a/src/core/gradient.ts
+++ b/src/core/gradient.ts
@@ -7,11 +7,50 @@
 
 import * as gradientOps from '../common/ops/gradient';
 import { NDArrayCore } from '../common/ndarray-core';
-import { fromStorage, fromStorageArray, toStorage } from './types';
+import * as shapeOps from '../common/ops/shape';
+import { asarray, full } from './creation';
+import { type ArrayLike, fromStorage, fromStorageArray, toStorage } from './types';
+
+/**
+ * Expand a `prepend`/`append` value for `diff` to a shape that's compatible
+ * with `a` for concatenation along `axis` (NumPy: scalar broadcasts to size 1
+ * along axis with `a`'s shape on all other axes).
+ */
+function expandDiffSide(
+  value: ArrayLike,
+  a: NDArrayCore,
+  axis: number,
+): NDArrayCore {
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    const targetShape = Array.from(a.shape);
+    targetShape[axis] = 1;
+    return full(targetShape, value, a.dtype as import('../common/dtype').DType);
+  }
+  return asarray(value);
+}
 
 /** Calculate n-th discrete difference */
-export function diff(a: NDArrayCore, n?: number, axis?: number): NDArrayCore {
-  return fromStorage(gradientOps.diff(toStorage(a), n, axis));
+export function diff(
+  a: NDArrayCore,
+  n?: number,
+  axis?: number,
+  prepend?: ArrayLike,
+  append?: ArrayLike,
+): NDArrayCore {
+  if (prepend === undefined && append === undefined) {
+    return fromStorage(gradientOps.diff(toStorage(a), n, axis));
+  }
+  const ndim = toStorage(a).ndim;
+  const ax = axis === undefined ? ndim - 1 : axis < 0 ? ndim + axis : axis;
+  const parts: NDArrayCore[] = [];
+  if (prepend !== undefined) parts.push(expandDiffSide(prepend, a, ax));
+  parts.push(a);
+  if (append !== undefined) parts.push(expandDiffSide(append, a, ax));
+  const combined = shapeOps.concatenate(
+    parts.map((p) => toStorage(p)),
+    ax,
+  );
+  return fromStorage(gradientOps.diff(combined, n, axis));
 }
 
 /** Difference between consecutive elements in 1D array */
@@ -39,7 +78,10 @@ export function gradient(
     opVarargs = varargs.map((v) => {
       if (typeof v === 'number') return v;
       if (v instanceof NDArrayCore) {
-        return Array.from(toStorage(v).data as ArrayLike<number>, (x) => Number(x));
+        return Array.from(
+          toStorage(v).data as { length: number; [n: number]: number | bigint },
+          (x) => Number(x),
+        );
       }
       return v;
     });

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -333,6 +333,7 @@ export {
   unique_inverse,
   unique_values,
 } from './sets';
+export type { NestedNDArrays } from './shape';
 // Shape manipulation
 export {
   array_split,

--- a/src/core/reduction.ts
+++ b/src/core/reduction.ts
@@ -5,9 +5,143 @@
  * imported independently for optimal tree-shaking.
  */
 
+import type { DType } from '../common/dtype';
+import * as arithmeticOps from '../common/ops/arithmetic';
 import * as reductionOps from '../common/ops/reduction';
 import * as shapeOps from '../common/ops/shape';
-import { ArrayStorage, Complex, fromStorage, type NDArrayCore, toStorage } from './types';
+import * as sortingOps from '../common/ops/sorting';
+import { asarray } from './creation';
+import {
+  type ArrayLike,
+  ArrayStorage,
+  Complex,
+  fromStorage,
+  type NDArrayCore,
+  toStorage,
+} from './types';
+
+// ============================================================
+// Reduction options (where=, initial=, dtype=)
+// ============================================================
+
+export interface ReductionOpts {
+  /** Boolean mask. Only elements where `where` is True are included in the reduction. */
+  where?: ArrayLike;
+  /** Starting value for the reduction (combined with the result per-op). */
+  initial?: number | bigint | boolean;
+  /** Force input cast to this dtype before reducing. */
+  dtype?: DType;
+}
+
+type ReductionKind = 'sum' | 'prod' | 'max' | 'min' | 'all' | 'any';
+
+/** Per-op identity element used to mask out non-`where` positions. */
+function identityFor(kind: ReductionKind, dtype: DType): number | bigint | boolean {
+  switch (kind) {
+    case 'sum':
+      return dtype.startsWith('int') || dtype.startsWith('uint') ? 0 : 0;
+    case 'prod':
+      return 1;
+    case 'max':
+      return dtype === 'float64' || dtype === 'float32' || dtype === 'float16'
+        ? -Infinity
+        : Number.MIN_SAFE_INTEGER;
+    case 'min':
+      return dtype === 'float64' || dtype === 'float32' || dtype === 'float16'
+        ? Infinity
+        : Number.MAX_SAFE_INTEGER;
+    case 'all':
+      return true;
+    case 'any':
+      return false;
+  }
+}
+
+/** Apply dtype cast and `where` mask to the input. Returns transformed storage. */
+function prepareReductionInput(
+  a: NDArrayCore,
+  kind: ReductionKind,
+  opts?: ReductionOpts,
+): ArrayStorage {
+  let storage = opts?.dtype ? toStorage(a.astype(opts.dtype)) : toStorage(a);
+  if (opts?.where !== undefined) {
+    const maskStorage = toStorage(asarray(opts.where));
+    const identity = identityFor(kind, storage.dtype as DType);
+    const fillStorage = ArrayStorage.empty(Array.from(storage.shape), storage.dtype);
+    if (typeof identity === 'boolean') {
+      for (let i = 0; i < fillStorage.size; i++) fillStorage.iset(i, identity ? 1 : 0);
+    } else {
+      for (let i = 0; i < fillStorage.size; i++) fillStorage.iset(i, identity as number | bigint);
+    }
+    storage = sortingOps.where(maskStorage, storage, fillStorage) as ArrayStorage;
+  }
+  return storage;
+}
+
+/** Combine the reduction result with `initial` using the op's combiner. */
+function combineWithInitial(
+  result: NDArrayCore | number | bigint | boolean | Complex,
+  initial: number | bigint | boolean,
+  kind: ReductionKind,
+): NDArrayCore | number | bigint | boolean | Complex {
+  if (result instanceof Complex) {
+    // Complex + scalar initial: only sum/prod meaningful here.
+    if (kind === 'sum') return new Complex(result.re + Number(initial), result.im);
+    if (kind === 'prod') {
+      const k = Number(initial);
+      return new Complex(result.re * k, result.im * k);
+    }
+    return result;
+  }
+
+  if (typeof result === 'number' || typeof result === 'bigint' || typeof result === 'boolean') {
+    const r = Number(result);
+    const k = Number(initial);
+    switch (kind) {
+      case 'sum':
+        return typeof result === 'bigint' ? result + BigInt(k) : r + k;
+      case 'prod':
+        return typeof result === 'bigint' ? result * BigInt(k) : r * k;
+      case 'max':
+        return Math.max(r, k);
+      case 'min':
+        return Math.min(r, k);
+      case 'all':
+        return Boolean(r) && Boolean(initial);
+      case 'any':
+        return Boolean(r) || Boolean(initial);
+    }
+  }
+
+  // NDArrayCore result — combine elementwise via core arithmetic ops.
+  const resStorage = toStorage(result);
+  const k = Number(initial);
+  switch (kind) {
+    case 'sum':
+      return fromStorage(arithmeticOps.add(resStorage, k));
+    case 'prod':
+      return fromStorage(arithmeticOps.multiply(resStorage, k));
+    case 'max':
+      return fromStorage(arithmeticOps.maximum(resStorage, k));
+    case 'min':
+      return fromStorage(arithmeticOps.minimum(resStorage, k));
+    case 'all':
+      // result && Boolean(initial): if initial is falsy, result becomes all-false.
+      if (!Boolean(initial)) {
+        const out = ArrayStorage.zeros(Array.from(resStorage.shape), resStorage.dtype);
+        return fromStorage(out);
+      }
+      return fromStorage(resStorage);
+    case 'any':
+      // result || Boolean(initial): if initial is truthy, result becomes all-true.
+      if (Boolean(initial)) {
+        const out = ArrayStorage.empty(Array.from(resStorage.shape), resStorage.dtype);
+        for (let i = 0; i < out.size; i++) out.iset(i, 1);
+        return fromStorage(out);
+      }
+      return fromStorage(resStorage);
+  }
+}
 
 // ============================================================
 // Multi-axis reduction helper
@@ -66,15 +200,27 @@ export function sum(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArrayCore | number | bigint | Complex {
+  const input = fromStorage(prepareReductionInput(a, 'sum', opts));
+  let result: NDArrayCore | number | bigint | Complex;
   if (Array.isArray(axis)) {
-    return reduceMultiAxis(a, axis, keepdims ?? false, (s, ax, kd) => reductionOps.sum(s, ax, kd));
+    result = reduceMultiAxis(input, axis, keepdims ?? false, (s, ax, kd) =>
+      reductionOps.sum(s, ax, kd),
+    ) as NDArrayCore | number | bigint | Complex;
+  } else {
+    const r = reductionOps.sum(toStorage(input), axis, keepdims);
+    result =
+      typeof r === 'number' || typeof r === 'bigint' || r instanceof Complex ? r : fromStorage(r);
   }
-  const result = reductionOps.sum(toStorage(a), axis, keepdims);
-  if (typeof result === 'number' || typeof result === 'bigint' || result instanceof Complex) {
-    return result;
+  if (opts?.initial !== undefined) {
+    return combineWithInitial(result, opts.initial, 'sum') as
+      | NDArrayCore
+      | number
+      | bigint
+      | Complex;
   }
-  return fromStorage(result);
+  return result;
 }
 
 /** Mean of array elements */
@@ -100,15 +246,27 @@ export function prod(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArrayCore | number | bigint | Complex {
+  const input = fromStorage(prepareReductionInput(a, 'prod', opts));
+  let result: NDArrayCore | number | bigint | Complex;
   if (Array.isArray(axis)) {
-    return reduceMultiAxis(a, axis, keepdims ?? false, (s, ax, kd) => reductionOps.prod(s, ax, kd));
+    result = reduceMultiAxis(input, axis, keepdims ?? false, (s, ax, kd) =>
+      reductionOps.prod(s, ax, kd),
+    ) as NDArrayCore | number | bigint | Complex;
+  } else {
+    const r = reductionOps.prod(toStorage(input), axis, keepdims);
+    result =
+      typeof r === 'number' || typeof r === 'bigint' || r instanceof Complex ? r : fromStorage(r);
   }
-  const result = reductionOps.prod(toStorage(a), axis, keepdims);
-  if (typeof result === 'number' || typeof result === 'bigint' || result instanceof Complex) {
-    return result;
+  if (opts?.initial !== undefined) {
+    return combineWithInitial(result, opts.initial, 'prod') as
+      | NDArrayCore
+      | number
+      | bigint
+      | Complex;
   }
-  return fromStorage(result);
+  return result;
 }
 
 /** Maximum of array elements */
@@ -116,17 +274,22 @@ export function max(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArrayCore | number | Complex {
+  const input = fromStorage(prepareReductionInput(a, 'max', opts));
+  let result: NDArrayCore | number | Complex;
   if (Array.isArray(axis)) {
-    return reduceMultiAxis(a, axis, keepdims ?? false, (s, ax, kd) =>
+    result = reduceMultiAxis(input, axis, keepdims ?? false, (s, ax, kd) =>
       reductionOps.max(s, ax, kd),
     ) as NDArrayCore | number | Complex;
+  } else {
+    const r = reductionOps.max(toStorage(input), axis, keepdims);
+    result = typeof r === 'number' || r instanceof Complex ? r : fromStorage(r);
   }
-  const result = reductionOps.max(toStorage(a), axis, keepdims);
-  if (typeof result === 'number' || result instanceof Complex) {
-    return result;
+  if (opts?.initial !== undefined) {
+    return combineWithInitial(result, opts.initial, 'max') as NDArrayCore | number | Complex;
   }
-  return fromStorage(result);
+  return result;
 }
 
 /** Alias for max */
@@ -137,17 +300,22 @@ export function min(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArrayCore | number | Complex {
+  const input = fromStorage(prepareReductionInput(a, 'min', opts));
+  let result: NDArrayCore | number | Complex;
   if (Array.isArray(axis)) {
-    return reduceMultiAxis(a, axis, keepdims ?? false, (s, ax, kd) =>
+    result = reduceMultiAxis(input, axis, keepdims ?? false, (s, ax, kd) =>
       reductionOps.min(s, ax, kd),
     ) as NDArrayCore | number | Complex;
+  } else {
+    const r = reductionOps.min(toStorage(input), axis, keepdims);
+    result = typeof r === 'number' || r instanceof Complex ? r : fromStorage(r);
   }
-  const result = reductionOps.min(toStorage(a), axis, keepdims);
-  if (typeof result === 'number' || result instanceof Complex) {
-    return result;
+  if (opts?.initial !== undefined) {
+    return combineWithInitial(result, opts.initial, 'min') as NDArrayCore | number | Complex;
   }
-  return fromStorage(result);
+  return result;
 }
 
 /** Alias for min */
@@ -156,9 +324,27 @@ export const amin = min;
 /** Peak-to-peak (max - min) */
 export function ptp(
   a: NDArrayCore,
-  axis?: number,
+  axis?: number | number[],
   keepdims?: boolean,
 ): NDArrayCore | number | Complex {
+  if (Array.isArray(axis)) {
+    // ptp does not compose under repeated reduction; compute as max - min across the axes.
+    const maxResult = reduceMultiAxis(a, axis, keepdims ?? false, (s, ax, kd) =>
+      reductionOps.max(s, ax, kd),
+    );
+    const minResult = reduceMultiAxis(a, axis, keepdims ?? false, (s, ax, kd) =>
+      reductionOps.min(s, ax, kd),
+    );
+    if (typeof maxResult === 'number' && typeof minResult === 'number') {
+      return maxResult - minResult;
+    }
+    if (maxResult instanceof Complex || minResult instanceof Complex) {
+      throw new Error('multi-axis ptp not supported for complex');
+    }
+    return fromStorage(
+      arithmeticOps.subtract(toStorage(maxResult as NDArrayCore), toStorage(minResult as NDArrayCore)),
+    );
+  }
   const result = reductionOps.ptp(toStorage(a), axis, keepdims);
   if (typeof result === 'number' || result instanceof Complex) {
     return result;
@@ -170,16 +356,47 @@ export function ptp(
 // Index of Extrema
 // ============================================================
 
+/**
+ * Re-introduce a size-1 dimension to an arg-reduction result, matching
+ * NumPy's `keepdims=True` behavior introduced in 1.22.
+ */
+function applyArgKeepdims(
+  result: ArrayStorage | number,
+  a: NDArrayCore,
+  axis: number | undefined,
+): NDArrayCore {
+  const ndim = toStorage(a).ndim;
+  if (typeof result === 'number') {
+    // Full reduction → shape of all 1s.
+    const onesShape = Array<number>(ndim).fill(1);
+    const out = ArrayStorage.zeros(onesShape, 'int64');
+    out.iset(0, BigInt(result));
+    return fromStorage(out);
+  }
+  const normAxis = axis === undefined ? 0 : axis < 0 ? ndim + axis : axis;
+  return fromStorage(shapeOps.expandDims(result, normAxis));
+}
+
 /** Index of minimum value */
-export function argmin(a: NDArrayCore, axis?: number): NDArrayCore | number {
+export function argmin(
+  a: NDArrayCore,
+  axis?: number,
+  keepdims?: boolean,
+): NDArrayCore | number {
   const result = reductionOps.argmin(toStorage(a), axis);
+  if (keepdims) return applyArgKeepdims(result, a, axis);
   if (typeof result === 'number') return result;
   return fromStorage(result);
 }
 
 /** Index of maximum value */
-export function argmax(a: NDArrayCore, axis?: number): NDArrayCore | number {
+export function argmax(
+  a: NDArrayCore,
+  axis?: number,
+  keepdims?: boolean,
+): NDArrayCore | number {
   const result = reductionOps.argmax(toStorage(a), axis);
+  if (keepdims) return applyArgKeepdims(result, a, axis);
   if (typeof result === 'number') return result;
   return fromStorage(result);
 }
@@ -267,17 +484,53 @@ export function quantile(
   return fromStorage(result);
 }
 
-/** Weighted average */
+/**
+ * Weighted average. When `returned` is true, returns `[avg, sum_of_weights]`
+ * (matching `np.average(..., returned=True)`); otherwise returns just `avg`.
+ */
 export function average(
   a: NDArrayCore,
   axis?: number,
   weights?: NDArrayCore,
   keepdims?: boolean,
-): NDArrayCore | number | Complex {
+  returned?: boolean,
+): NDArrayCore | number | Complex | [NDArrayCore | number | Complex, NDArrayCore | number] {
   const weightsStorage = weights ? toStorage(weights) : undefined;
-  const result = reductionOps.average(toStorage(a), axis, weightsStorage, keepdims);
-  if (typeof result === 'number' || result instanceof Complex) return result;
-  return fromStorage(result);
+  const rawAvg = reductionOps.average(toStorage(a), axis, weightsStorage, keepdims);
+  const avg: NDArrayCore | number | Complex =
+    typeof rawAvg === 'number' || rawAvg instanceof Complex ? rawAvg : fromStorage(rawAvg);
+
+  if (!returned) return avg;
+
+  // sum_of_weights: sum of weights along axis when given, else element count per slice.
+  let sumOfWeights: NDArrayCore | number;
+  if (weights) {
+    const sw = reductionOps.sum(toStorage(weights), axis, keepdims);
+    sumOfWeights =
+      typeof sw === 'number' || typeof sw === 'bigint'
+        ? Number(sw)
+        : sw instanceof Complex
+          ? sw.re
+          : fromStorage(sw);
+  } else {
+    const aStorage = toStorage(a);
+    if (axis === undefined) {
+      sumOfWeights = aStorage.size;
+    } else {
+      const ndim = aStorage.ndim;
+      const normAxis = axis < 0 ? ndim + axis : axis;
+      const count = aStorage.shape[normAxis]!;
+      // Build a result-shaped array filled with `count`.
+      const outShape = Array.from(aStorage.shape);
+      if (keepdims) outShape[normAxis] = 1;
+      else outShape.splice(normAxis, 1);
+      const fill = ArrayStorage.empty(outShape, 'float64');
+      for (let i = 0; i < fill.size; i++) fill.iset(i, count);
+      sumOfWeights = fromStorage(fill);
+    }
+  }
+
+  return [avg, sumOfWeights];
 }
 
 // ============================================================
@@ -289,15 +542,22 @@ export function all(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArrayCore | boolean {
+  const input = fromStorage(prepareReductionInput(a, 'all', opts));
+  let result: NDArrayCore | boolean;
   if (Array.isArray(axis)) {
-    return reduceMultiAxis(a, axis, keepdims ?? false, (s, ax, kd) =>
+    result = reduceMultiAxis(input, axis, keepdims ?? false, (s, ax, kd) =>
       reductionOps.all(s, ax, kd),
     ) as NDArrayCore | boolean;
+  } else {
+    const r = reductionOps.all(toStorage(input), axis, keepdims);
+    result = typeof r === 'boolean' ? r : fromStorage(r);
   }
-  const result = reductionOps.all(toStorage(a), axis, keepdims);
-  if (typeof result === 'boolean') return result;
-  return fromStorage(result);
+  if (opts?.initial !== undefined) {
+    return combineWithInitial(result, opts.initial, 'all') as NDArrayCore | boolean;
+  }
+  return result;
 }
 
 /** Test if any element is true */
@@ -305,15 +565,22 @@ export function any(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArrayCore | boolean {
+  const input = fromStorage(prepareReductionInput(a, 'any', opts));
+  let result: NDArrayCore | boolean;
   if (Array.isArray(axis)) {
-    return reduceMultiAxis(a, axis, keepdims ?? false, (s, ax, kd) =>
+    result = reduceMultiAxis(input, axis, keepdims ?? false, (s, ax, kd) =>
       reductionOps.any(s, ax, kd),
     ) as NDArrayCore | boolean;
+  } else {
+    const r = reductionOps.any(toStorage(input), axis, keepdims);
+    result = typeof r === 'boolean' ? r : fromStorage(r);
   }
-  const result = reductionOps.any(toStorage(a), axis, keepdims);
-  if (typeof result === 'boolean') return result;
-  return fromStorage(result);
+  if (opts?.initial !== undefined) {
+    return combineWithInitial(result, opts.initial, 'any') as NDArrayCore | boolean;
+  }
+  return result;
 }
 
 // ============================================================

--- a/src/core/reduction.ts
+++ b/src/core/reduction.ts
@@ -127,14 +127,14 @@ function combineWithInitial(
       return fromStorage(arithmeticOps.minimum(resStorage, k));
     case 'all':
       // result && Boolean(initial): if initial is falsy, result becomes all-false.
-      if (!Boolean(initial)) {
+      if (!initial) {
         const out = ArrayStorage.zeros(Array.from(resStorage.shape), resStorage.dtype);
         return fromStorage(out);
       }
       return fromStorage(resStorage);
     case 'any':
       // result || Boolean(initial): if initial is truthy, result becomes all-true.
-      if (Boolean(initial)) {
+      if (initial) {
         const out = ArrayStorage.empty(Array.from(resStorage.shape), resStorage.dtype);
         for (let i = 0; i < out.size; i++) out.iset(i, 1);
         return fromStorage(out);
@@ -342,7 +342,10 @@ export function ptp(
       throw new Error('multi-axis ptp not supported for complex');
     }
     return fromStorage(
-      arithmeticOps.subtract(toStorage(maxResult as NDArrayCore), toStorage(minResult as NDArrayCore)),
+      arithmeticOps.subtract(
+        toStorage(maxResult as NDArrayCore),
+        toStorage(minResult as NDArrayCore),
+      ),
     );
   }
   const result = reductionOps.ptp(toStorage(a), axis, keepdims);
@@ -378,11 +381,7 @@ function applyArgKeepdims(
 }
 
 /** Index of minimum value */
-export function argmin(
-  a: NDArrayCore,
-  axis?: number,
-  keepdims?: boolean,
-): NDArrayCore | number {
+export function argmin(a: NDArrayCore, axis?: number, keepdims?: boolean): NDArrayCore | number {
   const result = reductionOps.argmin(toStorage(a), axis);
   if (keepdims) return applyArgKeepdims(result, a, axis);
   if (typeof result === 'number') return result;
@@ -390,11 +389,7 @@ export function argmin(
 }
 
 /** Index of maximum value */
-export function argmax(
-  a: NDArrayCore,
-  axis?: number,
-  keepdims?: boolean,
-): NDArrayCore | number {
+export function argmax(a: NDArrayCore, axis?: number, keepdims?: boolean): NDArrayCore | number {
   const result = reductionOps.argmax(toStorage(a), axis);
   if (keepdims) return applyArgKeepdims(result, a, axis);
   if (typeof result === 'number') return result;

--- a/src/core/shape-extra.ts
+++ b/src/core/shape-extra.ts
@@ -226,12 +226,71 @@ export function insert(
   throw new Error('insert along axis not fully implemented in standalone');
 }
 
+export type PadWidthArg = number | [number, number] | (number | [number, number])[];
+export type PadValueArg = number | [number, number] | (number | [number, number])[];
+
+/**
+ * Normalize a pad_width / constant_values argument to per-axis [before, after] pairs.
+ *
+ * Accepts (matching NumPy):
+ *  - scalar `n` → `[[n, n], ...]` for every axis
+ *  - `[n]` (length 1) → `[[n, n], ...]` for every axis
+ *  - `[before, after]` (length 2) → broadcast to every axis
+ *  - `[n0, n1, ..., n_{ndim-1}]` (length ndim) → per-axis scalars (before=after=n_k)
+ *  - `[[b, a]]` (length 1) → broadcast pair to every axis
+ *  - `[[b0, a0], ..., [b_{ndim-1}, a_{ndim-1}]]` (length ndim) → per-axis pairs
+ *  - mixed: `[n0, [b1, a1], ...]` — scalars expand to (n, n)
+ */
+function normalizePerAxisPair(
+  v: PadWidthArg,
+  ndim: number,
+  paramName: string,
+): [number, number][] {
+  if (typeof v === 'number') {
+    return Array.from({ length: ndim }, () => [v, v] as [number, number]);
+  }
+  if (!Array.isArray(v) || v.length === 0) {
+    throw new Error(`${paramName} must be a number, pair, or non-empty list`);
+  }
+
+  // Distinguish "list of scalars" from "list of pairs (or mixed)"
+  const allNumbers = v.every((x) => typeof x === 'number');
+  if (allNumbers) {
+    const nums = v as number[];
+    if (nums.length === 1) {
+      const n = nums[0]!;
+      return Array.from({ length: ndim }, () => [n, n] as [number, number]);
+    }
+    if (nums.length === 2) {
+      const pair: [number, number] = [nums[0]!, nums[1]!];
+      return Array.from({ length: ndim }, () => [...pair] as [number, number]);
+    }
+    if (nums.length === ndim) {
+      return nums.map((n) => [n, n] as [number, number]);
+    }
+    throw new Error(`${paramName} length ${nums.length} does not match ndim ${ndim}`);
+  }
+
+  // List of pairs (or mixed scalars/pairs)
+  const toPair = (item: number | [number, number]): [number, number] =>
+    typeof item === 'number' ? [item, item] : ([item[0]!, item[1]!] as [number, number]);
+
+  if (v.length === 1) {
+    const pair = toPair(v[0]!);
+    return Array.from({ length: ndim }, () => [...pair] as [number, number]);
+  }
+  if (v.length !== ndim) {
+    throw new Error(`${paramName} length ${v.length} does not match ndim ${ndim}`);
+  }
+  return v.map(toPair);
+}
+
 /**
  * Pad an array
  */
 export function pad(
   arr: NDArrayCore,
-  pad_width: number | [number, number] | [number, number][],
+  pad_width: PadWidthArg,
   mode:
     | 'constant'
     | 'edge'
@@ -244,26 +303,32 @@ export function pad(
     | 'symmetric'
     | 'wrap'
     | 'empty' = 'constant',
-  constant_values: number = 0,
+  constant_values: PadValueArg = 0,
 ): NDArrayCore {
   const shape = [...arr.shape];
   const ndim = shape.length;
 
-  // Normalize pad_width to [[before, after], ...] for each dimension
-  let padWidths: [number, number][];
-  if (typeof pad_width === 'number') {
-    padWidths = Array(ndim).fill([pad_width, pad_width]) as [number, number][];
-  } else if (Array.isArray(pad_width) && typeof pad_width[0] === 'number') {
-    padWidths = Array(ndim).fill(pad_width as [number, number]) as [number, number][];
-  } else {
-    padWidths = pad_width as [number, number][];
-  }
+  const padWidths = normalizePerAxisPair(pad_width, ndim, 'pad_width');
+  const padValues = normalizePerAxisPair(constant_values, ndim, 'constant_values');
 
   // Calculate new shape
   const newShape = shape.map((s, i) => s + padWidths[i]![0] + padWidths[i]![1]);
 
+  // True if every axis uses (constantValue, constantValue) — enables the
+  // simple "pre-fill then copy source" fast paths below.
+  const uniformValue = padValues.every(
+    (p) => p[0] === padValues[0]![0] && p[1] === padValues[0]![0],
+  );
+  const scalarFillValue = uniformValue ? padValues[0]![0] : 0;
+
   // WASM fast path for 2D uniform zero-pad
-  if (mode === 'constant' && constant_values === 0 && ndim === 2 && typeof pad_width === 'number') {
+  if (
+    mode === 'constant' &&
+    uniformValue &&
+    scalarFillValue === 0 &&
+    ndim === 2 &&
+    typeof pad_width === 'number'
+  ) {
     const wasm = wasmPad2D(arr.storage, pad_width);
     if (wasm) {
       return new NDArrayCore(wasm);
@@ -274,35 +339,73 @@ export function pad(
     throw new Error(`pad mode '${mode}' not fully implemented in standalone`);
   }
 
-  // Create result array filled with constant value
   const result = zeros(newShape, arr.dtype as DType);
   const resultStorage = result.storage;
-  if (constant_values !== 0) {
-    for (let i = 0; i < result.size; i++) {
-      resultStorage.iset(i, constant_values);
-    }
-  }
-
-  // Copy original data into the padded position
   const srcStorage = arr.storage;
 
-  // Calculate strides for multi-index iteration (logical C-contiguous strides)
+  // Strides for multi-index iteration (logical C-contiguous)
   const strides: number[] = [];
   let stride = 1;
   for (let i = shape.length - 1; i >= 0; i--) {
     strides.unshift(stride);
     stride *= shape[i]!;
   }
-
   const newStrides: number[] = [];
   stride = 1;
   for (let i = newShape.length - 1; i >= 0; i--) {
     newStrides.unshift(stride);
     stride *= newShape[i]!;
   }
-
-  // Copy data
   const totalSize = shape.reduce((a, b) => a * b, 1);
+
+  // Per-axis value path: paint output cell-by-cell. NumPy applies pad axis-by-axis
+  // in order, so the *highest* axis whose pad covers a given cell wins.
+  if (!uniformValue) {
+    const newSize = result.size;
+    for (let outFlat = 0; outFlat < newSize; outFlat++) {
+      const idx: number[] = new Array(ndim);
+      let remaining = outFlat;
+      for (let k = 0; k < ndim; k++) {
+        idx[k] = Math.floor(remaining / newStrides[k]!);
+        remaining %= newStrides[k]!;
+      }
+
+      // Find highest axis whose pad covers this cell.
+      let fillValue: number | undefined;
+      for (let k = ndim - 1; k >= 0; k--) {
+        const i = idx[k]!;
+        const pb = padWidths[k]![0];
+        const sz = shape[k]!;
+        if (i < pb) {
+          fillValue = padValues[k]![0];
+          break;
+        }
+        if (i >= pb + sz) {
+          fillValue = padValues[k]![1];
+          break;
+        }
+      }
+
+      if (fillValue !== undefined) {
+        resultStorage.iset(outFlat, fillValue);
+      } else {
+        // In source region; copy from input.
+        let srcFlat = 0;
+        for (let k = 0; k < ndim; k++) {
+          srcFlat += (idx[k]! - padWidths[k]![0]) * strides[k]!;
+        }
+        resultStorage.iset(outFlat, srcStorage.iget(srcFlat));
+      }
+    }
+    return result;
+  }
+
+  // Uniform-value fast paths below (mirror previous behavior).
+  if (scalarFillValue !== 0) {
+    for (let i = 0; i < result.size; i++) {
+      resultStorage.iset(i, scalarFillValue);
+    }
+  }
 
   // Float16Array optimization: bulk-convert for faster per-element access
   if (
@@ -316,9 +419,8 @@ export function pad(
     );
     const resultSize = resultStorage.size;
     const f32Result = new Float32Array(resultSize);
-    // Pre-fill with constant value if non-zero
-    if (constant_values !== 0) {
-      f32Result.fill(constant_values);
+    if (scalarFillValue !== 0) {
+      f32Result.fill(scalarFillValue);
     }
 
     for (let flatIdx = 0; flatIdx < totalSize; flatIdx++) {
@@ -342,7 +444,6 @@ export function pad(
   }
 
   for (let flatIdx = 0; flatIdx < totalSize; flatIdx++) {
-    // Get multi-index in original array
     const multiIdx: number[] = [];
     let remaining = flatIdx;
     for (let i = 0; i < shape.length; i++) {
@@ -350,7 +451,6 @@ export function pad(
       remaining = remaining % strides[i]!;
     }
 
-    // Calculate new index with padding offset
     let newFlatIdx = 0;
     for (let i = 0; i < newShape.length; i++) {
       newFlatIdx += (multiIdx[i]! + padWidths[i]![0]) * newStrides[i]!;

--- a/src/core/shape-extra.ts
+++ b/src/core/shape-extra.ts
@@ -241,11 +241,7 @@ export type PadValueArg = number | [number, number] | (number | [number, number]
  *  - `[[b0, a0], ..., [b_{ndim-1}, a_{ndim-1}]]` (length ndim) → per-axis pairs
  *  - mixed: `[n0, [b1, a1], ...]` — scalars expand to (n, n)
  */
-function normalizePerAxisPair(
-  v: PadWidthArg,
-  ndim: number,
-  paramName: string,
-): [number, number][] {
+function normalizePerAxisPair(v: PadWidthArg, ndim: number, paramName: string): [number, number][] {
   if (typeof v === 'number') {
     return Array.from({ length: ndim }, () => [v, v] as [number, number]);
   }

--- a/src/core/shape.ts
+++ b/src/core/shape.ts
@@ -124,9 +124,15 @@ export function column_stack(arrays: NDArrayCore[]): NDArrayCore {
 /** vstack alias */
 export const row_stack = vstack;
 
-/** Assemble arrays from nested sequences of blocks */
-export function block(arrays: NDArrayCore[]): NDArrayCore {
-  return fromStorage(shapeOps.block(arrays.map((a) => toStorage(a))));
+export type NestedNDArrays = NDArrayCore | NestedNDArrays[];
+
+function mapNestedToStorage(x: NestedNDArrays): shapeOps.NestedBlock {
+  return Array.isArray(x) ? x.map(mapNestedToStorage) : toStorage(x);
+}
+
+/** Assemble arrays from nested sequences of blocks (np.block semantics) */
+export function block(arrays: NestedNDArrays[]): NDArrayCore {
+  return fromStorage(shapeOps.block(mapNestedToStorage(arrays)));
 }
 
 // ============================================================

--- a/src/core/shape.ts
+++ b/src/core/shape.ts
@@ -75,10 +75,7 @@ export function rollaxis(a: NDArrayCore, axis: number, start: number = 0): NDArr
  * Join arrays along an existing axis. Pass `axis=null` to flatten each input
  * and concatenate the result along axis 0 (matches `np.concatenate(..., axis=None)`).
  */
-export function concatenate(
-  arrays: NDArrayCore[],
-  axis: number | null = 0,
-): NDArrayCore {
+export function concatenate(arrays: NDArrayCore[], axis: number | null = 0): NDArrayCore {
   if (axis === null) {
     const flattened = arrays.map((a) => shapeOps.ravel(toStorage(a)));
     return fromStorage(shapeOps.concatenate(flattened, 0));

--- a/src/core/shape.ts
+++ b/src/core/shape.ts
@@ -71,8 +71,18 @@ export function rollaxis(a: NDArrayCore, axis: number, start: number = 0): NDArr
 // Joining Arrays
 // ============================================================
 
-/** Join arrays along an existing axis */
-export function concatenate(arrays: NDArrayCore[], axis: number = 0): NDArrayCore {
+/**
+ * Join arrays along an existing axis. Pass `axis=null` to flatten each input
+ * and concatenate the result along axis 0 (matches `np.concatenate(..., axis=None)`).
+ */
+export function concatenate(
+  arrays: NDArrayCore[],
+  axis: number | null = 0,
+): NDArrayCore {
+  if (axis === null) {
+    const flattened = arrays.map((a) => shapeOps.ravel(toStorage(a)));
+    return fromStorage(shapeOps.concatenate(flattened, 0));
+  }
   return fromStorage(
     shapeOps.concatenate(
       arrays.map((a) => toStorage(a)),
@@ -107,7 +117,11 @@ export function dstack(arrays: NDArrayCore[]): NDArrayCore {
 }
 
 /** Concatenate (alias) */
-export function concat(arrays: NDArrayCore[], axis: number = 0): NDArrayCore {
+export function concat(arrays: NDArrayCore[], axis: number | null = 0): NDArrayCore {
+  if (axis === null) {
+    const flattened = arrays.map((a) => shapeOps.ravel(toStorage(a)));
+    return fromStorage(shapeOps.concat(flattened, 0));
+  }
   return fromStorage(
     shapeOps.concat(
       arrays.map((a) => toStorage(a)),

--- a/src/core/sorting.ts
+++ b/src/core/sorting.ts
@@ -6,7 +6,9 @@
  */
 
 import * as sortingOps from '../common/ops/sorting';
+import { asarray } from './creation';
 import {
+  type ArrayLike,
   type ArrayStorage,
   fromStorage,
   fromStorageArray,
@@ -70,13 +72,13 @@ export function flatnonzero(a: NDArrayCore): NDArrayCore {
 /** Return elements from x or y based on condition */
 export function where(
   condition: NDArrayCore,
-  x?: NDArrayCore,
-  y?: NDArrayCore,
+  x?: ArrayLike,
+  y?: ArrayLike,
 ): NDArrayCore | NDArrayCore[] {
   const result = sortingOps.where(
     toStorage(condition),
-    x ? toStorage(x) : undefined,
-    y ? toStorage(y) : undefined,
+    x !== undefined ? toStorage(asarray(x)) : undefined,
+    y !== undefined ? toStorage(asarray(y)) : undefined,
   );
   if (Array.isArray(result)) {
     return fromStorageArray(result);

--- a/src/core/statistics.ts
+++ b/src/core/statistics.ts
@@ -12,18 +12,14 @@ import {
   type ArrayLike,
   type ArrayStorage,
   fromStorage,
-  NDArrayCore,
+  type NDArrayCore,
   toStorage,
 } from './types';
 
 type BinStrategyString = 'auto' | 'fd' | 'doane' | 'scott' | 'stone' | 'rice' | 'sturges' | 'sqrt';
 
 /** Count occurrences of values */
-export function bincount(
-  x: ArrayLike,
-  weights?: ArrayLike,
-  minlength?: number,
-): NDArrayCore {
+export function bincount(x: ArrayLike, weights?: ArrayLike, minlength?: number): NDArrayCore {
   const weightsStorage = weights !== undefined ? toStorage(asarray(weights)) : undefined;
   return fromStorage(statisticsOps.bincount(toStorage(asarray(x)), weightsStorage, minlength));
 }

--- a/src/core/statistics.ts
+++ b/src/core/statistics.ts
@@ -7,33 +7,49 @@
 
 import { Complex } from '../common/complex';
 import * as statisticsOps from '../common/ops/statistics';
-import { type ArrayStorage, fromStorage, NDArrayCore, toStorage } from './types';
+import { asarray } from './creation';
+import {
+  type ArrayLike,
+  type ArrayStorage,
+  fromStorage,
+  NDArrayCore,
+  toStorage,
+} from './types';
 
 type BinStrategyString = 'auto' | 'fd' | 'doane' | 'scott' | 'stone' | 'rice' | 'sturges' | 'sqrt';
 
 /** Count occurrences of values */
-export function bincount(x: NDArrayCore, weights?: NDArrayCore, minlength?: number): NDArrayCore {
-  const weightsStorage = weights ? toStorage(weights) : undefined;
-  return fromStorage(statisticsOps.bincount(toStorage(x), weightsStorage, minlength));
+export function bincount(
+  x: ArrayLike,
+  weights?: ArrayLike,
+  minlength?: number,
+): NDArrayCore {
+  const weightsStorage = weights !== undefined ? toStorage(asarray(weights)) : undefined;
+  return fromStorage(statisticsOps.bincount(toStorage(asarray(x)), weightsStorage, minlength));
 }
 
 /** Digitize values into bins */
-export function digitize(x: NDArrayCore, bins: NDArrayCore, right?: boolean): NDArrayCore {
-  return fromStorage(statisticsOps.digitize(toStorage(x), toStorage(bins), right));
+export function digitize(x: ArrayLike, bins: ArrayLike, right?: boolean): NDArrayCore {
+  return fromStorage(
+    statisticsOps.digitize(toStorage(asarray(x)), toStorage(asarray(bins)), right),
+  );
 }
 
 /** Compute histogram */
 export function histogram(
-  a: NDArrayCore,
-  bins?: number | NDArrayCore | BinStrategyString,
+  a: ArrayLike,
+  bins?: number | ArrayLike | BinStrategyString,
   range?: [number, number],
   density?: boolean,
-  weights?: NDArrayCore,
+  weights?: ArrayLike,
 ): [NDArrayCore, NDArrayCore] {
-  const binsArg = bins instanceof NDArrayCore ? toStorage(bins) : bins;
-  const weightsArg = weights ? toStorage(weights) : undefined;
+  const binsArg =
+    typeof bins === 'number' || typeof bins === 'string' || bins === undefined
+      ? bins
+      : toStorage(asarray(bins));
+  const weightsArg = weights !== undefined ? toStorage(asarray(weights)) : undefined;
   const result = statisticsOps.histogram(
-    toStorage(a),
+    toStorage(asarray(a)),
     binsArg as number | ArrayStorage | undefined,
     range,
     density,
@@ -45,27 +61,29 @@ export function histogram(
 
 /** Compute 2D histogram */
 export function histogram2d(
-  x: NDArrayCore,
-  y: NDArrayCore,
-  bins?: number | [number, number] | [NDArrayCore, NDArrayCore],
+  x: ArrayLike,
+  y: ArrayLike,
+  bins?: number | [number, number] | [ArrayLike, ArrayLike],
   range?: [[number, number], [number, number]],
   density?: boolean,
-  weights?: NDArrayCore,
+  weights?: ArrayLike,
 ): [NDArrayCore, NDArrayCore, NDArrayCore] {
   let binsArg: number | [number, number] | [ArrayStorage, ArrayStorage] | undefined;
   if (Array.isArray(bins) && bins.length === 2) {
-    const b0 = bins[0] instanceof NDArrayCore ? toStorage(bins[0]) : bins[0];
-    const b1 = bins[1] instanceof NDArrayCore ? toStorage(bins[1]) : bins[1];
+    const b0raw = bins[0];
+    const b1raw = bins[1];
+    const b0 = typeof b0raw === 'number' ? b0raw : toStorage(asarray(b0raw));
+    const b1 = typeof b1raw === 'number' ? b1raw : toStorage(asarray(b1raw));
     binsArg = [b0 as number | ArrayStorage, b1 as number | ArrayStorage] as
       | [number, number]
       | [ArrayStorage, ArrayStorage];
   } else {
     binsArg = bins as number | undefined;
   }
-  const weightsArg = weights ? toStorage(weights) : undefined;
+  const weightsArg = weights !== undefined ? toStorage(asarray(weights)) : undefined;
   const result = statisticsOps.histogram2d(
-    toStorage(x),
-    toStorage(y),
+    toStorage(asarray(x)),
+    toStorage(asarray(y)),
     binsArg,
     range,
     density,
@@ -76,14 +94,20 @@ export function histogram2d(
 
 /** Compute N-dimensional histogram */
 export function histogramdd(
-  sample: NDArrayCore,
+  sample: ArrayLike,
   bins?: number | number[],
   range?: [number, number][],
   density?: boolean,
-  weights?: NDArrayCore,
+  weights?: ArrayLike,
 ): [NDArrayCore, NDArrayCore[]] {
-  const weightsArg = weights ? toStorage(weights) : undefined;
-  const result = statisticsOps.histogramdd(toStorage(sample), bins, range, density, weightsArg);
+  const weightsArg = weights !== undefined ? toStorage(asarray(weights)) : undefined;
+  const result = statisticsOps.histogramdd(
+    toStorage(asarray(sample)),
+    bins,
+    range,
+    density,
+    weightsArg,
+  );
   return [fromStorage(result.hist), result.edges.map((e) => fromStorage(e))];
 }
 

--- a/src/full/index.ts
+++ b/src/full/index.ts
@@ -26,6 +26,7 @@ import { NDArrayCore } from '../common/ndarray-core';
 import { ArrayStorage } from '../common/storage';
 import * as core from '../core';
 import type { NestedNDArrays } from '../core/shape';
+import type { PadValueArg, PadWidthArg } from '../core/shape-extra';
 import type { ArrayLike, DType, TypedArray } from '../core/types';
 import { NDArray } from './ndarray';
 
@@ -1500,7 +1501,7 @@ export function insert(
  */
 export function pad(
   arr: NDArrayCore,
-  pad_width: number | [number, number] | [number, number][],
+  pad_width: PadWidthArg,
   mode:
     | 'constant'
     | 'edge'
@@ -1513,7 +1514,7 @@ export function pad(
     | 'symmetric'
     | 'wrap'
     | 'empty' = 'constant',
-  constant_values: number = 0,
+  constant_values: PadValueArg = 0,
 ): NDArray {
   return up(core.pad(arr, pad_width, mode, constant_values));
 }

--- a/src/full/index.ts
+++ b/src/full/index.ts
@@ -1701,12 +1701,12 @@ export function extract(condition: NDArrayCore, a: NDArrayCore): NDArray {
 }
 
 /** Count occurrences of values */
-export function bincount(x: NDArrayCore, weights?: NDArrayCore, minlength?: number): NDArray {
+export function bincount(x: ArrayLike, weights?: ArrayLike, minlength?: number): NDArray {
   return up(core.bincount(x, weights, minlength));
 }
 
 /** Digitize values into bins */
-export function digitize(x: NDArrayCore, bins: NDArrayCore, right?: boolean): NDArray {
+export function digitize(x: ArrayLike, bins: ArrayLike, right?: boolean): NDArray {
   return up(core.digitize(x, bins, right));
 }
 

--- a/src/full/index.ts
+++ b/src/full/index.ts
@@ -94,9 +94,9 @@ export function bindex(a: NDArrayCore, mask: NDArrayCore, axis?: number): NDArra
 }
 
 export function select(
-  condlist: NDArrayCore[],
-  choicelist: NDArrayCore[],
-  defaultVal: number = 0,
+  condlist: ArrayLike[],
+  choicelist: ArrayLike[],
+  defaultVal: ArrayLike = 0,
 ): NDArray {
   return up(core.select(condlist, choicelist, defaultVal));
 }

--- a/src/full/index.ts
+++ b/src/full/index.ts
@@ -25,6 +25,7 @@ import {
 import { NDArrayCore } from '../common/ndarray-core';
 import { ArrayStorage } from '../common/storage';
 import * as core from '../core';
+import type { ReductionOpts } from '../core/reduction';
 import type { NestedNDArrays } from '../core/shape';
 import type { PadValueArg, PadWidthArg } from '../core/shape-extra';
 import type { ArrayLike, DType, TypedArray } from '../core/types';
@@ -1110,8 +1111,9 @@ export function sum(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArray | number | bigint | Complex {
-  const r = core.sum(a, axis, keepdims);
+  const r = core.sum(a, axis, keepdims, opts);
   return r instanceof NDArrayCore ? up(r) : r;
 }
 
@@ -1130,8 +1132,9 @@ export function prod(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArray | number | bigint | Complex {
-  const r = core.prod(a, axis, keepdims);
+  const r = core.prod(a, axis, keepdims, opts);
   return r instanceof NDArrayCore ? up(r) : r;
 }
 
@@ -1140,8 +1143,9 @@ export function max(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArray | number | Complex {
-  const r = core.max(a, axis, keepdims);
+  const r = core.max(a, axis, keepdims, opts);
   return r instanceof NDArrayCore ? up(r) : r;
 }
 
@@ -1150,26 +1154,31 @@ export function min(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArray | number | Complex {
-  const r = core.min(a, axis, keepdims);
+  const r = core.min(a, axis, keepdims, opts);
   return r instanceof NDArrayCore ? up(r) : r;
 }
 
 /** Peak-to-peak (max - min) */
-export function ptp(a: NDArrayCore, axis?: number, keepdims?: boolean): NDArray | number | Complex {
+export function ptp(
+  a: NDArrayCore,
+  axis?: number | number[],
+  keepdims?: boolean,
+): NDArray | number | Complex {
   const r = core.ptp(a, axis, keepdims);
   return r instanceof NDArrayCore ? up(r) : r;
 }
 
 /** Index of minimum value */
-export function argmin(a: NDArrayCore, axis?: number): NDArray | number {
-  const r = core.argmin(a, axis);
+export function argmin(a: NDArrayCore, axis?: number, keepdims?: boolean): NDArray | number {
+  const r = core.argmin(a, axis, keepdims);
   return r instanceof NDArrayCore ? up(r) : r;
 }
 
 /** Index of maximum value */
-export function argmax(a: NDArrayCore, axis?: number): NDArray | number {
-  const r = core.argmax(a, axis);
+export function argmax(a: NDArrayCore, axis?: number, keepdims?: boolean): NDArray | number {
+  const r = core.argmax(a, axis, keepdims);
   return r instanceof NDArrayCore ? up(r) : r;
 }
 
@@ -1227,14 +1236,24 @@ export function quantile(
   return r instanceof NDArrayCore ? up(r) : r;
 }
 
-/** Weighted average */
+/**
+ * Weighted average. When `returned` is true, returns `[avg, sum_of_weights]`
+ * (matching `np.average(..., returned=True)`); otherwise returns just `avg`.
+ */
 export function average(
   a: NDArrayCore,
   axis?: number,
   weights?: NDArrayCore,
   keepdims?: boolean,
-): NDArray | number | Complex {
-  const r = core.average(a, axis, weights, keepdims);
+  returned?: boolean,
+): NDArray | number | Complex | [NDArray | number | Complex, NDArray | number] {
+  const r = core.average(a, axis, weights, keepdims, returned);
+  if (Array.isArray(r)) {
+    const [avg, sw] = r;
+    const upAvg = avg instanceof NDArrayCore ? up(avg) : avg;
+    const upSw = sw instanceof NDArrayCore ? up(sw) : sw;
+    return [upAvg, upSw];
+  }
   return r instanceof NDArrayCore ? up(r) : r;
 }
 
@@ -1243,8 +1262,9 @@ export function all(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArray | boolean {
-  const r = core.all(a, axis, keepdims);
+  const r = core.all(a, axis, keepdims, opts);
   return r instanceof NDArrayCore ? up(r) : r;
 }
 
@@ -1253,8 +1273,9 @@ export function any(
   a: NDArrayCore,
   axis?: number | number[],
   keepdims?: boolean,
+  opts?: ReductionOpts,
 ): NDArray | boolean {
-  const r = core.any(a, axis, keepdims);
+  const r = core.any(a, axis, keepdims, opts);
   return r instanceof NDArrayCore ? up(r) : r;
 }
 

--- a/src/full/index.ts
+++ b/src/full/index.ts
@@ -151,14 +151,15 @@ export function mask_indices(
 }
 
 export function apply_along_axis(
-  func1d: (arr: NDArrayCore) => NDArrayCore | number,
+  func1d: (arr: NDArrayCore, ...args: unknown[]) => NDArrayCore | number,
   axis: number,
   arr: NDArrayCore,
+  ...args: unknown[]
 ): NDArray {
-  const wrappedFunc1d = (arr: NDArrayCore): NDArrayCore | number => {
-    return func1d(up(arr));
+  const wrappedFunc1d = (arr: NDArrayCore, ...passed: unknown[]): NDArrayCore | number => {
+    return func1d(up(arr), ...passed);
   };
-  return up(core.apply_along_axis(wrappedFunc1d, axis, arr));
+  return up(core.apply_along_axis(wrappedFunc1d, axis, arr, ...args));
 }
 
 export function apply_over_axes(
@@ -756,8 +757,14 @@ export function fromfile(
 }
 
 /** Calculate n-th discrete difference */
-export function diff(a: NDArrayCore, n?: number, axis?: number): NDArray {
-  return up(core.diff(a, n, axis));
+export function diff(
+  a: NDArrayCore,
+  n?: number,
+  axis?: number,
+  prepend?: ArrayLike,
+  append?: ArrayLike,
+): NDArray {
+  return up(core.diff(a, n, axis, prepend, append));
 }
 
 /** Difference between consecutive elements in 1D array */
@@ -1586,8 +1593,11 @@ export function rollaxis(a: NDArrayCore, axis: number, start: number = 0): NDArr
   return up(core.rollaxis(a, axis, start));
 }
 
-/** Join arrays along an existing axis */
-export function concatenate(arrays: NDArrayCore[], axis: number = 0): NDArray {
+/**
+ * Join arrays along an existing axis. Pass `axis=null` to flatten each input
+ * and concatenate the result along axis 0 (matches `np.concatenate(..., axis=None)`).
+ */
+export function concatenate(arrays: NDArrayCore[], axis: number | null = 0): NDArray {
   return up(core.concatenate(arrays, axis));
 }
 
@@ -1612,7 +1622,7 @@ export function dstack(arrays: NDArrayCore[]): NDArray {
 }
 
 /** Concatenate (alias) */
-export function concat(arrays: NDArrayCore[], axis: number = 0): NDArray {
+export function concat(arrays: NDArrayCore[], axis: number | null = 0): NDArray {
   return up(core.concat(arrays, axis));
 }
 

--- a/src/full/index.ts
+++ b/src/full/index.ts
@@ -401,15 +401,17 @@ export function nan_to_num(
   return up(core.nan_to_num(x, nan, posinf, neginf));
 }
 
-/** 1D linear interpolation */
+/** 1D linear interpolation. If `period` is given, x and xp are normalized into
+ *  `[0, period)` and the curve wraps at the boundary; `left`/`right` are ignored. */
 export function interp(
   x: NDArrayCore,
   xp: NDArrayCore,
   fp: NDArrayCore,
   left?: number,
   right?: number,
+  period?: number,
 ): NDArray {
-  return up(core.interp(x, xp, fp, left, right));
+  return up(core.interp(x, xp, fp, left, right, period));
 }
 
 /** Unwrap phase angles */

--- a/src/full/index.ts
+++ b/src/full/index.ts
@@ -25,6 +25,7 @@ import {
 import { NDArrayCore } from '../common/ndarray-core';
 import { ArrayStorage } from '../common/storage';
 import * as core from '../core';
+import type { NestedNDArrays } from '../core/shape';
 import type { DType, TypedArray } from '../core/types';
 import { NDArray } from './ndarray';
 
@@ -1596,8 +1597,8 @@ export function column_stack(arrays: NDArrayCore[]): NDArray {
   return up(core.column_stack(arrays));
 }
 
-/** Assemble arrays from nested sequences of blocks */
-export function block(arrays: NDArrayCore[]): NDArray {
+/** Assemble arrays from nested sequences of blocks (np.block semantics) */
+export function block(arrays: NestedNDArrays[]): NDArray {
   return up(core.block(arrays));
 }
 

--- a/src/full/index.ts
+++ b/src/full/index.ts
@@ -26,7 +26,7 @@ import { NDArrayCore } from '../common/ndarray-core';
 import { ArrayStorage } from '../common/storage';
 import * as core from '../core';
 import type { NestedNDArrays } from '../core/shape';
-import type { DType, TypedArray } from '../core/types';
+import type { ArrayLike, DType, TypedArray } from '../core/types';
 import { NDArray } from './ndarray';
 
 // Helper to upgrade NDArrayCore to NDArray (zero-copy via shared storage)
@@ -54,7 +54,7 @@ export function broadcast_to(a: NDArrayCore, shape: number[]): NDArray {
   return up(core.broadcast_to(a, shape));
 }
 
-export function take(a: NDArrayCore, indices: number[], axis?: number): NDArray {
+export function take(a: NDArrayCore, indices: ArrayLike, axis?: number): NDArray {
   return up(core.take(a, indices, axis));
 }
 

--- a/src/full/ndarray.ts
+++ b/src/full/ndarray.ts
@@ -606,7 +606,7 @@ export class NDArray extends NDArrayCore {
    * @returns Weighted average of array elements
    */
   average(weights?: NDArray, axis?: number): NDArray | number | Complex {
-    const r = core.average(this, axis, weights);
+    const r = core.average(this, axis, weights, false, false) as NDArrayCore | number | Complex;
     return r instanceof NDArrayCore ? up(r) : r;
   }
 

--- a/src/full/ndarray.ts
+++ b/src/full/ndarray.ts
@@ -1698,49 +1698,57 @@ export class NDArray extends NDArrayCore {
  * @param indexing - 'xy' (Cartesian, default) or 'ij' (matrix indexing)
  * @returns Array of coordinate grids
  */
-export function meshgrid(...args: (NDArray | { indexing?: 'xy' | 'ij' })[]): NDArray[] {
+export interface MeshgridOptions {
+  /** 'xy' (default, NumPy-compatible) or 'ij' Cartesian/matrix indexing */
+  indexing?: 'xy' | 'ij';
+  /** If true, return open (non-broadcasted) grids — outputs have shape 1 except along their own axis */
+  sparse?: boolean;
+  /** If true (default), each output owns its data. If false, outputs are views (broadcast). */
+  copy?: boolean;
+}
+
+export function meshgrid(...args: (NDArray | MeshgridOptions)[]): NDArray[] {
   let arrays: NDArray[] = [];
   let indexing: 'xy' | 'ij' = 'xy';
+  let sparse = false;
+  let copy = true;
 
   for (const arg of args) {
     if (arg instanceof NDArray) {
       arrays.push(arg);
-    } else if (typeof arg === 'object' && 'indexing' in arg) {
-      indexing = arg.indexing || 'xy';
+    } else if (arg && typeof arg === 'object') {
+      if ('indexing' in arg && arg.indexing) indexing = arg.indexing;
+      if ('sparse' in arg && arg.sparse !== undefined) sparse = arg.sparse;
+      if ('copy' in arg && arg.copy !== undefined) copy = arg.copy;
     }
   }
 
-  if (arrays.length === 0) {
-    return [];
-  }
-
+  if (arrays.length === 0) return [];
   if (arrays.length === 1) {
-    return [arrays[0]!.copy()];
+    const a = arrays[0]!;
+    return [copy ? a.copy() : a];
   }
-
-  const sizes = arrays.map((a) => a.size);
 
   if (indexing === 'xy' && arrays.length >= 2) {
     arrays = [arrays[1]!, arrays[0]!, ...arrays.slice(2)];
-    [sizes[0], sizes[1]] = [sizes[1]!, sizes[0]!];
   }
 
-  const outputShape = sizes;
-  const ndim = outputShape.length;
+  const sizes = arrays.map((a) => a.size);
+  const ndim = sizes.length;
 
   const results: NDArray[] = [];
-
   for (let i = 0; i < arrays.length; i++) {
-    const inputArr = arrays[i]!;
-    const inputSize = inputArr.size;
-
     const broadcastShape: number[] = new Array(ndim).fill(1);
-    broadcastShape[i] = inputSize;
+    broadcastShape[i] = sizes[i]!;
 
-    const reshaped = inputArr.reshape(...broadcastShape);
-    const resultStorage = core.broadcast_to(reshaped, outputShape);
-    const result = NDArray.fromStorage(resultStorage.storage.copy());
-    results.push(result);
+    const reshaped = arrays[i]!.reshape(...broadcastShape);
+    if (sparse) {
+      results.push(copy ? reshaped.copy() : reshaped);
+      continue;
+    }
+    const broadcasted = core.broadcast_to(reshaped, sizes);
+    const out = NDArray.fromStorage(copy ? broadcasted.storage.copy() : broadcasted.storage);
+    results.push(out);
   }
 
   if (indexing === 'xy' && results.length >= 2) {

--- a/tests/validation/block.numpy.test.ts
+++ b/tests/validation/block.numpy.test.ts
@@ -1,0 +1,88 @@
+/**
+ * NumPy validation tests for np.block — verifies the recursive nested-list
+ * semantics match NumPy.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { block, empty } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: block', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) {
+      throw new Error('Python NumPy not available');
+    }
+  });
+
+  it('matches numpy on the canonical 2x2 nested example', () => {
+    const a = empty([2, 3]);
+    a.fill(1);
+    const b = empty([2, 2]);
+    b.fill(2);
+    const c = empty([1, 1]);
+    c.fill(3);
+    const d = empty([1, 4]);
+    d.fill(4);
+
+    const result = block([
+      [a, b],
+      [c, d],
+    ]);
+
+    const np = runNumPy(`
+a = np.empty([2, 3]); a.fill(1)
+b = np.empty([2, 2]); b.fill(2)
+c = np.empty([1, 1]); c.fill(3)
+d = np.empty([1, 4]); d.fill(4)
+result = np.block([[a, b], [c, d]])
+`);
+
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('matches numpy on a flat list (concat along axis -1)', () => {
+    const a = empty([2, 3]);
+    a.fill(1);
+    const b = empty([2, 2]);
+    b.fill(2);
+
+    const result = block([a, b]);
+
+    const np = runNumPy(`
+a = np.empty([2, 3]); a.fill(1)
+b = np.empty([2, 2]); b.fill(2)
+result = np.block([a, b])
+`);
+
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('matches numpy on a 3-deep nested example', () => {
+    const a = empty([1, 2, 2]);
+    a.fill(1);
+    const b = empty([1, 2, 2]);
+    b.fill(2);
+    const c = empty([1, 2, 4]);
+    c.fill(3);
+    const d = empty([1, 2, 4]);
+    d.fill(4);
+
+    const result = block([
+      [[a, b], [c]],
+      [[c], [a, b]],
+    ]);
+
+    const np = runNumPy(`
+a = np.empty([1, 2, 2]); a.fill(1)
+b = np.empty([1, 2, 2]); b.fill(2)
+c = np.empty([1, 2, 4]); c.fill(3)
+d = np.empty([1, 2, 4]); d.fill(4)
+result = np.block([[[a, b], [c]], [[c], [a, b]]])
+`);
+
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+});

--- a/tests/validation/gradient.numpy.test.ts
+++ b/tests/validation/gradient.numpy.test.ts
@@ -257,6 +257,57 @@ result = np.gradient(np.array([[1, 2, 4], [4, 8, 12]]), axis=1)
         expect(jsResult.shape).toEqual(pyResult.shape);
         expect(arraysClose(jsResult.toArray(), pyResult.value)).toBe(true);
       });
+
+      it('accepts a 1-D coordinate array (non-uniform spacing)', () => {
+        const f = array([1, 2, 4, 7, 11, 16]);
+        const x = [0.0, 1.0, 1.5, 3.5, 4.0, 6.0];
+        const jsResult = gradient(f, [x]) as any;
+        const pyResult = runNumPy(`
+f = np.array([1, 2, 4, 7, 11, 16], dtype=float)
+x = np.array([0.0, 1.0, 1.5, 3.5, 4.0, 6.0])
+result = np.gradient(f, x)
+      `);
+        expect(jsResult.shape).toEqual(pyResult.shape);
+        expect(arraysClose(jsResult.toArray(), pyResult.value, 1e-10)).toBe(true);
+      });
+
+      it('accepts mixed coord-array and scalar per axis', () => {
+        const f = array([
+          [1, 2, 6, 24],
+          [10, 20, 60, 240],
+          [100, 200, 600, 2400],
+        ]);
+        const ycoords = [0.0, 0.5, 1.0];
+        const [gy, gx] = gradient(f, [ycoords, 2]) as any;
+        const py0 = runNumPy(`
+f = np.array([[1, 2, 6, 24], [10, 20, 60, 240], [100, 200, 600, 2400]], dtype=float)
+y = np.array([0.0, 0.5, 1.0])
+gy, gx = np.gradient(f, y, 2)
+result = gy
+      `);
+        const py1 = runNumPy(`
+f = np.array([[1, 2, 6, 24], [10, 20, 60, 240], [100, 200, 600, 2400]], dtype=float)
+y = np.array([0.0, 0.5, 1.0])
+gy, gx = np.gradient(f, y, 2)
+result = gx
+      `);
+        expect(gy.shape).toEqual(py0.shape);
+        expect(arraysClose(gy.toArray(), py0.value, 1e-10)).toBe(true);
+        expect(arraysClose(gx.toArray(), py1.value, 1e-10)).toBe(true);
+      });
+
+      it('accepts NDArray as a coordinate spacing', () => {
+        const f = array([10, 20, 35, 80]);
+        const x = array([0.0, 1.0, 2.5, 5.0]);
+        const jsResult = gradient(f, [x]) as any;
+        const pyResult = runNumPy(`
+f = np.array([10, 20, 35, 80], dtype=float)
+x = np.array([0.0, 1.0, 2.5, 5.0])
+result = np.gradient(f, x)
+      `);
+        expect(jsResult.shape).toEqual(pyResult.shape);
+        expect(arraysClose(jsResult.toArray(), pyResult.value, 1e-10)).toBe(true);
+      });
     });
 
     describe('gradient (multi-dtype)', () => {

--- a/tests/validation/histogram-arraylike.numpy.test.ts
+++ b/tests/validation/histogram-arraylike.numpy.test.ts
@@ -1,0 +1,100 @@
+/**
+ * NumPy validation tests confirming bincount/histogram/histogram2d/histogramdd/digitize
+ * accept array-like inputs (plain number[]) without manual array() wrapping.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { bincount, digitize, histogram, histogram2d, histogramdd } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: histogram-family ArrayLike inputs', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) throw new Error('Python NumPy not available');
+  });
+
+  it('bincount accepts plain number[]', () => {
+    const result = bincount([0, 1, 1, 2, 2, 2, 3], [0.5, 1, 1, 2, 2, 2, 3]);
+    const np = runNumPy(`
+result = np.bincount(np.array([0, 1, 1, 2, 2, 2, 3]),
+                     weights=np.array([0.5, 1, 1, 2, 2, 2, 3]))
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('digitize accepts plain number[] for x and bins', () => {
+    const result = digitize([0.2, 6.4, 3.0, 1.6], [0.0, 1.0, 2.5, 4.0, 10.0]);
+    const np = runNumPy(`
+result = np.digitize(np.array([0.2, 6.4, 3.0, 1.6]), np.array([0.0, 1.0, 2.5, 4.0, 10.0]))
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('histogram accepts plain number[]', () => {
+    const [hist] = histogram([1, 2, 1, 2, 3, 4, 5, 5, 5], 5);
+    const np = runNumPy(`
+hist, _ = np.histogram(np.array([1, 2, 1, 2, 3, 4, 5, 5, 5]), bins=5)
+result = hist
+`);
+    expect(Array.from(hist.shape)).toEqual(np.shape);
+    expect(arraysClose(hist.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('histogram bins as plain number[]', () => {
+    const [hist] = histogram([0.1, 0.5, 0.9, 1.2, 2.7], [0, 1, 2, 3]);
+    const np = runNumPy(`
+hist, _ = np.histogram(np.array([0.1, 0.5, 0.9, 1.2, 2.7]), bins=[0, 1, 2, 3])
+result = hist
+`);
+    expect(Array.from(hist.shape)).toEqual(np.shape);
+    expect(arraysClose(hist.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('histogram2d accepts plain number[]', () => {
+    const [h] = histogram2d([1, 2, 3, 4], [1, 1, 4, 4], 2);
+    const np = runNumPy(`
+h, _, _ = np.histogram2d(np.array([1, 2, 3, 4]), np.array([1, 1, 4, 4]), bins=2)
+result = h
+`);
+    expect(Array.from(h.shape)).toEqual(np.shape);
+    expect(arraysClose(h.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('histogram2d bins as [number[], number[]]', () => {
+    const [h] = histogram2d(
+      [1, 2, 3, 4],
+      [1, 1, 4, 4],
+      [
+        [0, 2, 4],
+        [0, 2, 4],
+      ],
+    );
+    const np = runNumPy(`
+h, _, _ = np.histogram2d(np.array([1, 2, 3, 4]), np.array([1, 1, 4, 4]),
+                         bins=[[0, 2, 4], [0, 2, 4]])
+result = h
+`);
+    expect(Array.from(h.shape)).toEqual(np.shape);
+    expect(arraysClose(h.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('histogramdd accepts plain nested array', () => {
+    const [h] = histogramdd(
+      [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+        [7, 8],
+      ],
+      2,
+    );
+    const np = runNumPy(`
+sample = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+h, _ = np.histogramdd(sample, bins=2)
+result = h
+`);
+    expect(Array.from(h.shape)).toEqual(np.shape);
+    expect(arraysClose(h.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+});

--- a/tests/validation/interp.numpy.test.ts
+++ b/tests/validation/interp.numpy.test.ts
@@ -1,0 +1,82 @@
+/**
+ * NumPy validation tests for np.interp — focuses on the `period` kwarg.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { array, interp } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: interp', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) throw new Error('Python NumPy not available');
+  });
+
+  it('regression: works without period', () => {
+    const x = array([1.5, 2.5, 3.5]);
+    const xp = array([1.0, 2.0, 3.0, 4.0]);
+    const fp = array([10.0, 20.0, 30.0, 40.0]);
+    const result = interp(x, xp, fp);
+    const np = runNumPy(`
+x = np.array([1.5, 2.5, 3.5])
+xp = np.array([1.0, 2.0, 3.0, 4.0])
+fp = np.array([10.0, 20.0, 30.0, 40.0])
+result = np.interp(x, xp, fp)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('period=2*pi wraps at the boundary', () => {
+    // Interpolating sin samples on a periodic interval.
+    const xp = array([1.0, 2.0, 3.0, 4.0, 5.0]);
+    const fp = array([0.84, 0.91, 0.14, -0.76, -0.96]);
+    const x = array([-180.0, -90.0, 0.0, 90.0, 180.0]).multiply(Math.PI / 180);
+    const period = 2 * Math.PI;
+    const result = interp(x, xp, fp, undefined, undefined, period);
+    const np = runNumPy(`
+xp = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+fp = np.array([0.84, 0.91, 0.14, -0.76, -0.96])
+x = np.array([-180.0, -90.0, 0.0, 90.0, 180.0]) * np.pi / 180
+result = np.interp(x, xp, fp, period=2*np.pi)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('period handles unsorted xp by sorting internally', () => {
+    const xp = array([3.0, 1.0, 2.0, 4.0]);
+    const fp = array([30.0, 10.0, 20.0, 40.0]);
+    const x = array([0.5, 1.5, 2.5, 3.5, 4.5]);
+    const result = interp(x, xp, fp, undefined, undefined, 5);
+    const np = runNumPy(`
+xp = np.array([3.0, 1.0, 2.0, 4.0])
+fp = np.array([30.0, 10.0, 20.0, 40.0])
+x = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+result = np.interp(x, xp, fp, period=5)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('left/right are ignored when period is provided', () => {
+    const xp = array([1.0, 2.0, 3.0]);
+    const fp = array([10.0, 20.0, 30.0]);
+    const x = array([-100.0, 100.0]); // far outside [0, period); should still wrap
+    const result = interp(x, xp, fp, 999, 999, 4);
+    const np = runNumPy(`
+xp = np.array([1.0, 2.0, 3.0])
+fp = np.array([10.0, 20.0, 30.0])
+x = np.array([-100.0, 100.0])
+result = np.interp(x, xp, fp, left=999, right=999, period=4)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('period=0 throws', () => {
+    const x = array([1.0]);
+    const xp = array([0.0, 1.0]);
+    const fp = array([0.0, 1.0]);
+    expect(() => interp(x, xp, fp, undefined, undefined, 0)).toThrow();
+  });
+});

--- a/tests/validation/meshgrid.numpy.test.ts
+++ b/tests/validation/meshgrid.numpy.test.ts
@@ -1,0 +1,88 @@
+/**
+ * NumPy validation tests for np.meshgrid — verifies indexing/sparse/copy kwargs.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { array, meshgrid } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: meshgrid', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) throw new Error('Python NumPy not available');
+  });
+
+  it("default 'xy' indexing matches NumPy", () => {
+    const x = array([1, 2, 3]);
+    const y = array([10, 20]);
+    const [X, Y] = meshgrid(x, y);
+    const npX = runNumPy(`
+x = np.array([1, 2, 3]); y = np.array([10, 20])
+result, _ = np.meshgrid(x, y)
+`);
+    const npY = runNumPy(`
+x = np.array([1, 2, 3]); y = np.array([10, 20])
+_, result = np.meshgrid(x, y)
+`);
+    expect(Array.from(X!.shape)).toEqual(npX.shape);
+    expect(arraysClose(X!.toArray() as number[], npX.value, 1e-10)).toBe(true);
+    expect(arraysClose(Y!.toArray() as number[], npY.value, 1e-10)).toBe(true);
+  });
+
+  it("'ij' indexing matches NumPy", () => {
+    const x = array([1, 2, 3]);
+    const y = array([10, 20]);
+    const [X, Y] = meshgrid(x, y, { indexing: 'ij' });
+    const npX = runNumPy(`
+x = np.array([1, 2, 3]); y = np.array([10, 20])
+result, _ = np.meshgrid(x, y, indexing='ij')
+`);
+    const npY = runNumPy(`
+x = np.array([1, 2, 3]); y = np.array([10, 20])
+_, result = np.meshgrid(x, y, indexing='ij')
+`);
+    expect(Array.from(X!.shape)).toEqual(npX.shape);
+    expect(arraysClose(X!.toArray() as number[], npX.value, 1e-10)).toBe(true);
+    expect(arraysClose(Y!.toArray() as number[], npY.value, 1e-10)).toBe(true);
+  });
+
+  it("sparse=true matches NumPy", () => {
+    const x = array([1, 2, 3]);
+    const y = array([10, 20]);
+    const [X, Y] = meshgrid(x, y, { sparse: true });
+    const npX = runNumPy(`
+x = np.array([1, 2, 3]); y = np.array([10, 20])
+result, _ = np.meshgrid(x, y, sparse=True)
+`);
+    const npY = runNumPy(`
+x = np.array([1, 2, 3]); y = np.array([10, 20])
+_, result = np.meshgrid(x, y, sparse=True)
+`);
+    expect(Array.from(X!.shape)).toEqual(npX.shape);
+    expect(Array.from(Y!.shape)).toEqual(npY.shape);
+    expect(arraysClose(X!.toArray() as number[], npX.value, 1e-10)).toBe(true);
+    expect(arraysClose(Y!.toArray() as number[], npY.value, 1e-10)).toBe(true);
+  });
+
+  it("3D 'ij' indexing matches NumPy", () => {
+    const x = array([1, 2]);
+    const y = array([10, 20, 30]);
+    const z = array([100, 200]);
+    const [X, Y, Z] = meshgrid(x, y, z, { indexing: 'ij' });
+    const npX = runNumPy(`
+x = np.array([1, 2]); y = np.array([10, 20, 30]); z = np.array([100, 200])
+result, _, _ = np.meshgrid(x, y, z, indexing='ij')
+`);
+    const npY = runNumPy(`
+x = np.array([1, 2]); y = np.array([10, 20, 30]); z = np.array([100, 200])
+_, result, _ = np.meshgrid(x, y, z, indexing='ij')
+`);
+    const npZ = runNumPy(`
+x = np.array([1, 2]); y = np.array([10, 20, 30]); z = np.array([100, 200])
+_, _, result = np.meshgrid(x, y, z, indexing='ij')
+`);
+    expect(Array.from(X!.shape)).toEqual(npX.shape);
+    expect(arraysClose(X!.toArray() as number[], npX.value, 1e-10)).toBe(true);
+    expect(arraysClose(Y!.toArray() as number[], npY.value, 1e-10)).toBe(true);
+    expect(arraysClose(Z!.toArray() as number[], npZ.value, 1e-10)).toBe(true);
+  });
+});

--- a/tests/validation/meshgrid.numpy.test.ts
+++ b/tests/validation/meshgrid.numpy.test.ts
@@ -45,7 +45,7 @@ _, result = np.meshgrid(x, y, indexing='ij')
     expect(arraysClose(Y!.toArray() as number[], npY.value, 1e-10)).toBe(true);
   });
 
-  it("sparse=true matches NumPy", () => {
+  it('sparse=true matches NumPy', () => {
     const x = array([1, 2, 3]);
     const y = array([10, 20]);
     const [X, Y] = meshgrid(x, y, { sparse: true });

--- a/tests/validation/missing-kwargs-final.numpy.test.ts
+++ b/tests/validation/missing-kwargs-final.numpy.test.ts
@@ -1,0 +1,111 @@
+/**
+ * NumPy validation tests for the final batch of missing kwargs:
+ *  - concatenate(arrays, axis=null)
+ *  - diff(a, n, axis, prepend, append)
+ *  - apply_along_axis(func1d, axis, arr, ...args)
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { apply_along_axis, arange, array, concat, concatenate, diff } from '../../src';
+import type { NDArray } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: final-batch kwargs', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) throw new Error('Python NumPy not available');
+  });
+
+  describe('concatenate axis=null', () => {
+    it('flattens and concatenates 2-D inputs', () => {
+      const a = array([
+        [1, 2],
+        [3, 4],
+      ]);
+      const b = array([
+        [5, 6, 7],
+        [8, 9, 10],
+      ]);
+      const result = concatenate([a, b], null) as NDArray;
+      const np = runNumPy(`
+a = np.array([[1, 2], [3, 4]])
+b = np.array([[5, 6, 7], [8, 9, 10]])
+result = np.concatenate([a, b], axis=None)
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+
+    it('concat alias also supports axis=null', () => {
+      const a = array([
+        [1, 2],
+        [3, 4],
+      ]);
+      const result = concat([a, array([5, 6])], null) as NDArray;
+      const np = runNumPy(`
+a = np.array([[1, 2], [3, 4]])
+result = np.concatenate([a, np.array([5, 6])], axis=None)
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+  });
+
+  describe('diff prepend/append', () => {
+    it('scalar prepend and append on 1-D', () => {
+      const a = array([1, 2, 4, 7, 11]);
+      const result = diff(a, 1, undefined, 0, 100) as NDArray;
+      const np = runNumPy(`
+a = np.array([1, 2, 4, 7, 11])
+result = np.diff(a, prepend=0, append=100)
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+
+    it('array prepend on 2-D along default axis', () => {
+      const a = array([
+        [1, 3, 6, 10],
+        [2, 4, 8, 16],
+      ]);
+      const result = diff(a, 1, undefined, [[0], [0]]) as NDArray;
+      const np = runNumPy(`
+a = np.array([[1, 3, 6, 10], [2, 4, 8, 16]])
+result = np.diff(a, prepend=[[0], [0]])
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+
+    it('scalar prepend on 2-D along axis=0', () => {
+      const a = array([
+        [1, 2, 3],
+        [4, 5, 6],
+      ]);
+      const result = diff(a, 1, 0, 0) as NDArray;
+      const np = runNumPy(`
+a = np.array([[1, 2, 3], [4, 5, 6]])
+result = np.diff(a, axis=0, prepend=0)
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+  });
+
+  describe('apply_along_axis args forwarding', () => {
+    it('passes scalar args through to the callback', () => {
+      const a = arange(12).reshape(3, 4);
+      // Custom: sum elements > threshold
+      const sumGt = (row: NDArray, threshold: number) =>
+        ((row.toArray() as number[]).filter((x) => x > threshold).reduce((s, x) => s + x, 0) as number);
+      const result = apply_along_axis(sumGt as never, 1, a, 5) as NDArray;
+      const np = runNumPy(`
+a = np.arange(12).reshape(3, 4)
+def sum_gt(row, threshold):
+    return float(np.sum(row[row > threshold]))
+result = np.apply_along_axis(sum_gt, 1, a, 5)
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+  });
+});

--- a/tests/validation/missing-kwargs-final.numpy.test.ts
+++ b/tests/validation/missing-kwargs-final.numpy.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
-import { apply_along_axis, arange, array, concat, concatenate, diff } from '../../src';
 import type { NDArray } from '../../src';
+import { apply_along_axis, arange, array, concat, concatenate, diff } from '../../src';
 import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
 
 describe('NumPy Validation: final-batch kwargs', () => {
@@ -96,7 +96,9 @@ result = np.diff(a, axis=0, prepend=0)
       const a = arange(12).reshape(3, 4);
       // Custom: sum elements > threshold
       const sumGt = (row: NDArray, threshold: number) =>
-        ((row.toArray() as number[]).filter((x) => x > threshold).reduce((s, x) => s + x, 0) as number);
+        (row.toArray() as number[])
+          .filter((x) => x > threshold)
+          .reduce((s, x) => s + x, 0) as number;
       const result = apply_along_axis(sumGt as never, 1, a, 5) as NDArray;
       const np = runNumPy(`
 a = np.arange(12).reshape(3, 4)

--- a/tests/validation/pad.numpy.test.ts
+++ b/tests/validation/pad.numpy.test.ts
@@ -1,0 +1,93 @@
+/**
+ * NumPy validation tests for np.pad — verifies per-axis pad_width and
+ * per-axis constant_values support.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { arange, pad } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: pad', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) throw new Error('Python NumPy not available');
+  });
+
+  it('uniform scalar pad_width and value (regression)', () => {
+    const a = arange(6).reshape(2, 3);
+    const result = pad(a, 1, 'constant', 7);
+    const np = runNumPy(`
+a = np.arange(6).reshape(2, 3)
+result = np.pad(a, 1, mode='constant', constant_values=7)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('per-axis pad_width as nested pairs', () => {
+    const a = arange(6).reshape(2, 3);
+    const result = pad(
+      a,
+      [
+        [1, 2],
+        [3, 0],
+      ],
+      'constant',
+      0,
+    );
+    const np = runNumPy(`
+a = np.arange(6).reshape(2, 3)
+result = np.pad(a, [[1, 2], [3, 0]], mode='constant')
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('per-axis constant_values as pair of pairs', () => {
+    const a = arange(6).reshape(2, 3);
+    const result = pad(a, 1, 'constant', [
+      [10, 20],
+      [30, 40],
+    ]);
+    const np = runNumPy(`
+a = np.arange(6).reshape(2, 3)
+result = np.pad(a, 1, mode='constant', constant_values=[[10, 20], [30, 40]])
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('asymmetric pair broadcast across axes', () => {
+    const a = arange(6).reshape(2, 3);
+    const result = pad(a, [1, 2], 'constant', [3, 9]);
+    const np = runNumPy(`
+a = np.arange(6).reshape(2, 3)
+result = np.pad(a, [1, 2], mode='constant', constant_values=[3, 9])
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('per-axis scalars as 1-D list with length=ndim', () => {
+    const a = arange(6).reshape(2, 3);
+    const result = pad(a, [1, 2], 'constant', 0);
+    const np = runNumPy(`
+a = np.arange(6).reshape(2, 3)
+# In NumPy, [1, 2] for 2-D array is interpreted as [before, after] applied to all axes.
+result = np.pad(a, [1, 2], mode='constant')
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('mixed scalars and pairs for constant_values', () => {
+    const a = arange(6).reshape(2, 3);
+    const result = pad(a, 1, 'constant', [5, [7, 8]]);
+    const np = runNumPy(`
+a = np.arange(6).reshape(2, 3)
+# axis 0: before=after=5; axis 1: before=7, after=8
+result = np.pad(a, 1, mode='constant', constant_values=[[5, 5], [7, 8]])
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+});

--- a/tests/validation/reduction-extras.numpy.test.ts
+++ b/tests/validation/reduction-extras.numpy.test.ts
@@ -1,0 +1,136 @@
+/**
+ * NumPy validation tests for: argmin/argmax keepdims, ptp multi-axis,
+ * average returned=True.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { arange, argmax, argmin, array, average, ptp } from '../../src';
+import type { NDArray } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: reduction extras', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) throw new Error('Python NumPy not available');
+  });
+
+  describe('argmin / argmax keepdims', () => {
+    it('argmin axis=1 keepdims', () => {
+      const a = array([
+        [3, 1, 2],
+        [9, 4, 7],
+      ]);
+      const result = argmin(a, 1, true) as NDArray;
+      const np = runNumPy(`
+a = np.array([[3, 1, 2], [9, 4, 7]])
+result = np.argmin(a, axis=1, keepdims=True)
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+
+    it('argmax full reduction keepdims (shape of all 1s)', () => {
+      const a = arange(12).reshape(3, 4);
+      const result = argmax(a, undefined, true) as NDArray;
+      const np = runNumPy(`
+a = np.arange(12).reshape(3, 4)
+result = np.argmax(a, keepdims=True)
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+
+    it('argmax axis=0 keepdims preserves rank', () => {
+      const a = arange(24).reshape(2, 3, 4);
+      const result = argmax(a, 0, true) as NDArray;
+      const np = runNumPy(`
+a = np.arange(24).reshape(2, 3, 4)
+result = np.argmax(a, axis=0, keepdims=True)
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+  });
+
+  describe('ptp with multi-axis', () => {
+    it('ptp axis=[0,1] reduces both', () => {
+      const a = arange(24).reshape(2, 3, 4);
+      const result = ptp(a, [0, 1]) as NDArray;
+      const np = runNumPy(`
+a = np.arange(24).reshape(2, 3, 4)
+result = np.ptp(a, axis=(0, 1))
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+
+    it('ptp axis=[1,2] keepdims', () => {
+      const a = arange(24).reshape(2, 3, 4);
+      const result = ptp(a, [1, 2], true) as NDArray;
+      const np = runNumPy(`
+a = np.arange(24).reshape(2, 3, 4)
+result = np.ptp(a, axis=(1, 2), keepdims=True)
+`);
+      expect(Array.from(result.shape)).toEqual(np.shape);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+  });
+
+  describe('average returned=True', () => {
+    it('returns (avg, count) for unweighted full reduction', () => {
+      const a = array([1.0, 2.0, 3.0, 4.0]);
+      const [avg, sw] = average(a, undefined, undefined, undefined, true) as [number, number];
+      const npAvg = runNumPy(`
+a = np.array([1.0, 2.0, 3.0, 4.0])
+avg, sw = np.average(a, returned=True)
+result = float(avg)
+`);
+      const npSw = runNumPy(`
+a = np.array([1.0, 2.0, 3.0, 4.0])
+avg, sw = np.average(a, returned=True)
+result = float(sw)
+`);
+      expect(avg).toBeCloseTo(npAvg.value, 10);
+      expect(sw).toBeCloseTo(npSw.value, 10);
+    });
+
+    it('returns (avg, sum_of_weights) for weighted', () => {
+      const a = array([1.0, 2.0, 3.0, 4.0]);
+      const w = array([1, 2, 3, 4]);
+      const [avg, sw] = average(a, undefined, w, undefined, true) as [number, number];
+      const npAvg = runNumPy(`
+a = np.array([1.0, 2.0, 3.0, 4.0])
+w = np.array([1, 2, 3, 4])
+avg, sw = np.average(a, weights=w, returned=True)
+result = float(avg)
+`);
+      const npSw = runNumPy(`
+a = np.array([1.0, 2.0, 3.0, 4.0])
+w = np.array([1, 2, 3, 4])
+avg, sw = np.average(a, weights=w, returned=True)
+result = float(sw)
+`);
+      expect(avg).toBeCloseTo(npAvg.value, 10);
+      expect(sw).toBeCloseTo(npSw.value, 10);
+    });
+
+    it('axis-reduce returned along axis', () => {
+      const a = array([
+        [1.0, 2.0, 3.0],
+        [4.0, 5.0, 6.0],
+      ]);
+      const [avg, sw] = average(a, 0, undefined, undefined, true) as [NDArray, NDArray];
+      const npAvg = runNumPy(`
+a = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+avg, sw = np.average(a, axis=0, returned=True)
+result = avg
+`);
+      const npSw = runNumPy(`
+a = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+avg, sw = np.average(a, axis=0, returned=True)
+result = sw
+`);
+      expect(arraysClose(avg.toArray() as number[], npAvg.value, 1e-10)).toBe(true);
+      expect(arraysClose(sw.toArray() as number[], npSw.value, 1e-10)).toBe(true);
+    });
+  });
+});

--- a/tests/validation/reduction-extras.numpy.test.ts
+++ b/tests/validation/reduction-extras.numpy.test.ts
@@ -4,8 +4,8 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
-import { arange, argmax, argmin, array, average, ptp } from '../../src';
 import type { NDArray } from '../../src';
+import { arange, argmax, argmin, array, average, ptp } from '../../src';
 import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
 
 describe('NumPy Validation: reduction extras', () => {

--- a/tests/validation/reduction-kwargs.numpy.test.ts
+++ b/tests/validation/reduction-kwargs.numpy.test.ts
@@ -1,0 +1,150 @@
+/**
+ * NumPy validation tests for reduction kwargs: where=, initial=, dtype=.
+ * Covers sum, prod, max, min, all, any.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { all, any, arange, array, max, min, prod, sum } from '../../src';
+import type { NDArray } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: reduction kwargs', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) throw new Error('Python NumPy not available');
+  });
+
+  describe('where=', () => {
+    it('sum with boolean mask', () => {
+      const a = arange(10);
+      const mask = a.greater(3);
+      const result = sum(a, undefined, undefined, { where: mask }) as number;
+      const np = runNumPy(`
+a = np.arange(10)
+result = np.sum(a, where=a > 3)
+`);
+      expect(result).toBeCloseTo(np.value, 10);
+    });
+
+    it('sum along axis with where=', () => {
+      const a = array([
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ]);
+      const mask = a.greater(3);
+      const result = sum(a, 1, undefined, { where: mask }) as NDArray;
+      const np = runNumPy(`
+a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+result = np.sum(a, axis=1, where=a > 3)
+`);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+
+    it('prod with where=', () => {
+      const a = array([1, 2, 3, 4, 5]);
+      const result = prod(a, undefined, undefined, { where: [true, false, true, false, true] }) as number;
+      const np = runNumPy(`
+result = np.prod(np.array([1, 2, 3, 4, 5]), where=[True, False, True, False, True])
+`);
+      expect(result).toBeCloseTo(np.value, 10);
+    });
+
+    it('max with where=', () => {
+      const a = array([1, 100, 3, 50, 5]);
+      const result = max(a, undefined, undefined, { where: [true, false, true, false, true] }) as number;
+      const np = runNumPy(`
+result = np.max(np.array([1, 100, 3, 50, 5]),
+                where=np.array([True, False, True, False, True]),
+                initial=-1000000)
+`);
+      expect(result).toBe(np.value);
+    });
+
+    it('any with where=', () => {
+      const a = array([false, true, false, true]);
+      const result = any(a, undefined, undefined, { where: [true, false, true, false] }) as boolean;
+      const np = runNumPy(`
+result = np.any(np.array([False, True, False, True]), where=[True, False, True, False])
+`);
+      expect(result).toBe(Boolean(np.value));
+    });
+  });
+
+  describe('initial=', () => {
+    it('sum with initial', () => {
+      const a = arange(5);
+      const result = sum(a, undefined, undefined, { initial: 100 }) as number;
+      const np = runNumPy(`
+result = np.sum(np.arange(5), initial=100)
+`);
+      expect(result).toBeCloseTo(np.value, 10);
+    });
+
+    it('prod with initial', () => {
+      const a = array([1, 2, 3]);
+      const result = prod(a, undefined, undefined, { initial: 10 }) as number;
+      const np = runNumPy(`
+result = np.prod(np.array([1, 2, 3]), initial=10)
+`);
+      expect(result).toBeCloseTo(np.value, 10);
+    });
+
+    it('max with initial pulling result up', () => {
+      const a = array([1, 2, 3]);
+      const result = max(a, undefined, undefined, { initial: 100 }) as number;
+      const np = runNumPy(`
+result = np.max(np.array([1, 2, 3]), initial=100)
+`);
+      expect(result).toBe(np.value);
+    });
+
+    it('min with initial pulling result down', () => {
+      const a = array([10, 20, 30]);
+      const result = min(a, undefined, undefined, { initial: 5 }) as number;
+      const np = runNumPy(`
+result = np.min(np.array([10, 20, 30]), initial=5)
+`);
+      expect(result).toBe(np.value);
+    });
+
+    it('axis-reduce with initial broadcasts elementwise', () => {
+      const a = array([
+        [1, 2, 3],
+        [4, 5, 6],
+      ]);
+      const result = sum(a, 0, undefined, { initial: 100 }) as NDArray;
+      const np = runNumPy(`
+a = np.array([[1, 2, 3], [4, 5, 6]])
+result = np.sum(a, axis=0, initial=100)
+`);
+      expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+    });
+  });
+
+  describe('combined where= + initial=', () => {
+    it('all-False mask falls through to initial', () => {
+      const a = array([1, 2, 3]);
+      const result = sum(a, undefined, undefined, {
+        where: [false, false, false],
+        initial: 99,
+      }) as number;
+      const np = runNumPy(`
+result = np.sum(np.array([1, 2, 3]),
+                where=np.array([False, False, False]),
+                initial=99)
+`);
+      expect(result).toBe(np.value);
+    });
+  });
+
+  describe('dtype=', () => {
+    it('sum with dtype=float64 on int input', () => {
+      const a = arange(5);
+      const result = sum(a, undefined, undefined, { dtype: 'float64' }) as number;
+      const np = runNumPy(`
+result = float(np.sum(np.arange(5), dtype=np.float64))
+`);
+      expect(result).toBeCloseTo(np.value, 10);
+    });
+  });
+});

--- a/tests/validation/reduction-kwargs.numpy.test.ts
+++ b/tests/validation/reduction-kwargs.numpy.test.ts
@@ -4,8 +4,8 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
-import { all, any, arange, array, max, min, prod, sum } from '../../src';
 import type { NDArray } from '../../src';
+import { any, arange, array, max, min, prod, sum } from '../../src';
 import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
 
 describe('NumPy Validation: reduction kwargs', () => {
@@ -42,7 +42,9 @@ result = np.sum(a, axis=1, where=a > 3)
 
     it('prod with where=', () => {
       const a = array([1, 2, 3, 4, 5]);
-      const result = prod(a, undefined, undefined, { where: [true, false, true, false, true] }) as number;
+      const result = prod(a, undefined, undefined, {
+        where: [true, false, true, false, true],
+      }) as number;
       const np = runNumPy(`
 result = np.prod(np.array([1, 2, 3, 4, 5]), where=[True, False, True, False, True])
 `);
@@ -51,7 +53,9 @@ result = np.prod(np.array([1, 2, 3, 4, 5]), where=[True, False, True, False, Tru
 
     it('max with where=', () => {
       const a = array([1, 100, 3, 50, 5]);
-      const result = max(a, undefined, undefined, { where: [true, false, true, false, true] }) as number;
+      const result = max(a, undefined, undefined, {
+        where: [true, false, true, false, true],
+      }) as number;
       const np = runNumPy(`
 result = np.max(np.array([1, 100, 3, 50, 5]),
                 where=np.array([True, False, True, False, True]),

--- a/tests/validation/select.numpy.test.ts
+++ b/tests/validation/select.numpy.test.ts
@@ -1,0 +1,69 @@
+/**
+ * NumPy validation tests for np.select — verifies array-like condlist/choicelist
+ * and array-valued default support.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { arange, array, select } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: select', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) throw new Error('Python NumPy not available');
+  });
+
+  it('regression: scalar default with NDArray inputs', () => {
+    const x = arange(10);
+    const condlist = [x.less(3), x.greater(5)];
+    const choicelist = [x.multiply(10), x.multiply(-1)];
+    const result = select(condlist, choicelist, -99);
+    const np = runNumPy(`
+x = np.arange(10)
+result = np.select([x < 3, x > 5], [x*10, -x], default=-99)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('accepts plain number[] in condlist/choicelist', () => {
+    const result = select(
+      [
+        [true, false, true, false],
+        [false, true, false, true],
+      ],
+      [
+        [1, 2, 3, 4],
+        [10, 20, 30, 40],
+      ],
+      0,
+    );
+    const np = runNumPy(`
+result = np.select([[True, False, True, False], [False, True, False, True]],
+                   [[1, 2, 3, 4], [10, 20, 30, 40]], default=0)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('accepts an array-valued default (broadcasts against choices)', () => {
+    const x = arange(6);
+    const result = select([x.less(2), x.greater(4)], [x.multiply(100), x.multiply(-1)], x);
+    const np = runNumPy(`
+x = np.arange(6)
+result = np.select([x < 2, x > 4], [x*100, -x], default=x)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('plain number[] for default broadcasts elementwise', () => {
+    const cond = array([true, false, true, false]);
+    const result = select([cond], [[10, 20, 30, 40]], [1, 2, 3, 4]);
+    const np = runNumPy(`
+result = np.select([np.array([True, False, True, False])],
+                   [[10, 20, 30, 40]], default=[1, 2, 3, 4])
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+});

--- a/tests/validation/take.numpy.test.ts
+++ b/tests/validation/take.numpy.test.ts
@@ -1,0 +1,81 @@
+/**
+ * NumPy validation tests for np.take — verifies ndarray index support
+ * and that output shape preserves the indices' shape.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { arange, array, take } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: take', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) throw new Error('Python NumPy not available');
+  });
+
+  it('accepts a plain number[] (legacy)', () => {
+    const a = arange(12).reshape(3, 4);
+    const result = take(a, [0, 2], 1);
+    const np = runNumPy(`
+a = np.arange(12).reshape(3, 4)
+result = np.take(a, [0, 2], axis=1)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('accepts a 1D ndarray of indices', () => {
+    const a = arange(12).reshape(3, 4);
+    const idx = array([0, 2, 1]);
+    const result = take(a, idx, 1);
+    const np = runNumPy(`
+a = np.arange(12).reshape(3, 4)
+idx = np.array([0, 2, 1])
+result = np.take(a, idx, axis=1)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('preserves 2D index shape in the output', () => {
+    const a = arange(20);
+    const idx = array([
+      [0, 1, 2],
+      [3, 4, 5],
+    ]);
+    const result = take(a, idx);
+    const np = runNumPy(`
+a = np.arange(20)
+idx = np.array([[0, 1, 2], [3, 4, 5]])
+result = np.take(a, idx)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('preserves 2D index shape along an axis', () => {
+    const a = arange(24).reshape(2, 4, 3);
+    const idx = array([
+      [0, 2],
+      [1, 3],
+    ]);
+    const result = take(a, idx, 1);
+    const np = runNumPy(`
+a = np.arange(24).reshape(2, 4, 3)
+idx = np.array([[0, 2], [1, 3]])
+result = np.take(a, idx, axis=1)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('accepts a scalar index', () => {
+    const a = arange(12).reshape(3, 4);
+    const result = take(a, 2, 1);
+    const np = runNumPy(`
+a = np.arange(12).reshape(3, 4)
+result = np.take(a, 2, axis=1)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+});

--- a/tests/validation/where.numpy.test.ts
+++ b/tests/validation/where.numpy.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
-import { arange, array, where } from '../../src';
 import type { NDArray } from '../../src';
+import { arange, array, where } from '../../src';
 import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
 
 describe('NumPy Validation: where', () => {

--- a/tests/validation/where.numpy.test.ts
+++ b/tests/validation/where.numpy.test.ts
@@ -1,0 +1,72 @@
+/**
+ * NumPy validation tests for np.where — verifies scalar / array-like x/y inputs.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { arange, array, where } from '../../src';
+import type { NDArray } from '../../src';
+import { arraysClose, checkNumPyAvailable, runNumPy } from './numpy-oracle';
+
+describe('NumPy Validation: where', () => {
+  beforeAll(() => {
+    if (!checkNumPyAvailable()) throw new Error('Python NumPy not available');
+  });
+
+  it('accepts scalar x and y', () => {
+    const cond = array([true, false, true, false]);
+    const result = where(cond, 1, 0) as NDArray;
+    const np = runNumPy(`
+cond = np.array([True, False, True, False])
+result = np.where(cond, 1, 0)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('accepts scalar y with falsy 0', () => {
+    // Regression: previous `if (x)` check treated x=0 as undefined (bug).
+    const cond = array([true, false, true]);
+    const x = array([10, 20, 30]);
+    const result = where(cond, x, 0) as NDArray;
+    const np = runNumPy(`
+cond = np.array([True, False, True])
+x = np.array([10, 20, 30])
+result = np.where(cond, x, 0)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('accepts plain number[] for x and y', () => {
+    const cond = array([true, false, true]);
+    const result = where(cond, [1, 2, 3], [10, 20, 30]) as NDArray;
+    const np = runNumPy(`
+cond = np.array([True, False, True])
+result = np.where(cond, [1, 2, 3], [10, 20, 30])
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('broadcasts a scalar against an array', () => {
+    const a = arange(6).reshape(2, 3);
+    const result = where(a, a, -1) as NDArray;
+    const np = runNumPy(`
+a = np.arange(6).reshape(2, 3)
+result = np.where(a, a, -1)
+`);
+    expect(Array.from(result.shape)).toEqual(np.shape);
+    expect(arraysClose(result.toArray() as number[], np.value, 1e-10)).toBe(true);
+  });
+
+  it('still works with no x/y (returns indices)', () => {
+    const a = array([0, 1, 0, 2, 0, 3]);
+    const result = where(a) as NDArray[];
+    const np = runNumPy(`
+a = np.array([0, 1, 0, 2, 0, 3])
+result = list(np.where(a))
+`);
+    expect(result.length).toBe(np.value.length);
+    expect(arraysClose(result[0]!.toArray() as number[], np.value[0], 1e-10)).toBe(true);
+  });
+});


### PR DESCRIPTION
Expanded args for the following functions:

- `block` - accepts nested lists (NumPy block semantics)
- `take` - accepts ndarray indices, preserves index shape
- `where` - accepts scalar x/y; fixes silent x=0 bug
- `meshgrid` - adds `sparse` and `copy` options
- `pad` - full per-axis / pair / mixed forms for pad_width & constant_values
- `select` - array-like condlist/choicelist and array default
- `gradient` - per-axis coordinate-array spacings
- `interp` - `period` kwarg for periodic interpolation
- `bincount` / `digitize` / `histogram` / `histogram2d` / `histogramdd` - ArrayLike inputs
- `sum`/`prod`/`max`/`min`/`all`/`any` - `where=`, `initial=`, `dtype=`
- `argmin` / `argmax` - `keepdims`; `ptp` - multi-axis; `average` - `returned=True`
- `concatenate` - `axis=null`; `diff` - `prepend`/`append`; `apply_along_axis` - arg forwarding